### PR TITLE
BUG: version_short undefined if versioneer fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ version = versioneer.get_version()
 _version_short = re.findall('\d+\.\d+\.\d+', version)
 if len(_version_short) > 0:
     version_short = _version_short[0]
+else:
+    version_short = 'master'
 download_url = "https://github.com/libAtoms/matscipy/archive/%s.tar.gz" % version_short
 
 scripts = []


### PR DESCRIPTION
Fall back to master for the download url if versioneer can't determine the version.

It seems like versioneer needs the `.git` directory to come up with a version number; maybe there is a better fallback that it can do but this covers the case where it comes up with nothing.