### PR TITLE
Screw kinks

### DIFF
--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -568,7 +568,7 @@ def make_barrier_configurations(elastic_param=None,
     positions[fixed_atoms_indices] = new_av_pos
     disloc_fin.set_positions(positions, apply_constraint=False)
 
-    return disloc_fin, disloc_ini, bulk_ini
+    return disloc_ini, disloc_fin, bulk_ini
 
 def make_screw_cyl_kink(alat, C11, C12, C44,
                         cylinder_r=40, kink_length=26, kind="double", **kwargs):
@@ -608,7 +608,7 @@ def make_screw_cyl_kink(alat, C11, C12, C44,
     b = np.sqrt(3.0) * alat / 2.0
     cent_x = np.sqrt(6.0) * alat / 3.0
 
-    disloc_fin, disloc_ini, bulk_ini = make_barrier_configurations((alat, C11, C12, C44),
+    disloc_ini, disloc_fin, bulk_ini = make_barrier_configurations((alat, C11, C12, C44),
                                                                     cylinder_r=cylinder_r, **kwargs)
 
     if kind == "double":

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -266,6 +266,18 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         #  compare z component with simple Volterra solution
         self.assertArrayAlmostEqual(u_volterra, u_stroh[:, 2])
 
+    def test_make_screw_quadrupole_kink(self):
+        """Test the total number of atoms in the quadrupole double kink configuration"""
+
+        alat = 3.14
+        n1u = 5
+        kink_length = 20
+
+        kink, _, _ = sd.make_screw_quadrupole_kink(alat=alat, n1u=n1u, kink_length=kink_length)
+        quadrupole_base, _, _, _ = sd.make_screw_quadrupole(alat=alat, n1u=n1u)
+
+        self.assertEqual(len(kink), len(quadrupole_base) * 2 * kink_length)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -311,5 +311,41 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         self.assertArrayAlmostEqual(kink.positions[kink_fixed_atoms],
                                     large_disloc.positions[reference_fixed_atoms])
 
+    def test_slice_long_dislo(self):
+        """Function to test slicing tool"""
+
+        alat = 3.14339177996466
+        b = np.sqrt(3.0) * alat / 2.0
+        n1u = 5
+        kink_length = 20
+
+        kink, straight_dislo, kink_bulk = sd.make_screw_quadrupole_kink(alat=alat, n1u=n1u, kink_length=kink_length)
+        quadrupole_base, _, _, _ = sd.make_screw_quadrupole(alat=alat, n1u=n1u)
+
+        sliced_kink, core_positions = sd.slice_long_dislo(kink, kink_bulk, b)
+
+        # check the number of sliced configurations is equal to length of 2 * kink_length * 3 (for double kink)
+        self.assertEqual(len(sliced_kink), kink_length * 3 * 2)
+
+        # check that the bulk and kink slices are the same size
+        bulk_sizes = [len(slice[0]) for slice in sliced_kink]
+        kink_sizes = [len(slice[1]) for slice in sliced_kink]
+        self.assertArrayAlmostEqual(bulk_sizes, kink_sizes)
+
+        # check that the size of slices are the same as single b configuration
+        self.assertArrayAlmostEqual(len(quadrupole_base), len(sliced_kink[0][0]))
+
+        right_kink, straight_dislo, kink_bulk = sd.make_screw_quadrupole_kink(alat=alat, n1u=n1u, kind="right",
+                                                                              kink_length=kink_length)
+        sliced_right_kink, _ = sd.slice_long_dislo(right_kink, kink_bulk, b)
+        # check the number of sliced configurations is equal to length of kink_length * 3 - 2 (for right kink)
+        self.assertEqual(len(sliced_right_kink), kink_length * 3 - 2)
+
+        left_kink, straight_dislo, kink_bulk = sd.make_screw_quadrupole_kink(alat=alat, n1u=n1u, kind="left",
+                                                                              kink_length=kink_length)
+        sliced_left_kink, _ = sd.slice_long_dislo(left_kink, kink_bulk, b)
+        # check the number of sliced configurations is equal to length of kink_length * 3 - 1 (for left kink)
+        self.assertEqual(len(sliced_left_kink), kink_length * 3 - 1)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -278,6 +278,38 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
 
         self.assertEqual(len(kink), len(quadrupole_base) * 2 * kink_length)
 
+    @unittest.skipIf("atomman" not in sys.modules, 'requires Stroh solution from atomman to run')
+    def test_make_screw_cyl_kink(self):
+        """Test the total number of atoms and number of fixed atoms in the cylinder double kink configuration"""
+
+        alat = 3.14339177996466
+        C11 = 523.0266819809012
+        C12 = 202.1786296941397
+        C44 = 160.88179872237012
+
+        cent_x = np.sqrt(6.0) * alat / 3.0
+        center = [cent_x, 0.0, 0.0]
+
+        cylinder_r = 40
+        kink_length = 26
+
+        kink, large_disloc, straight_bulk = sd.make_screw_cyl_kink(alat, C11, C12, C44, kink_length=kink_length,
+                                                                   cylinder_r=cylinder_r, kind="double")
+
+        # check the total number of atoms as compared to make_screw_cyl()
+        disloc, _, _ = sd.make_screw_cyl(alat, C11, C12, C12, cylinder_r=cylinder_r, l_extend=center)
+
+        self.assertEqual(len(kink), len(disloc) * 2 * kink_length)
+
+        kink_fixed_atoms = kink.constraints[0].get_indices()
+        reference_fixed_atoms = kink.constraints[0].get_indices()
+
+        # check that the same number of atoms is fixed
+        self.assertEqual(len(kink_fixed_atoms), len(reference_fixed_atoms))
+        # check that the fixed atoms are the same and with same positions
+        self.assertArrayAlmostEqual(kink_fixed_atoms, reference_fixed_atoms)
+        self.assertArrayAlmostEqual(kink.positions[kink_fixed_atoms],
+                                    large_disloc.positions[reference_fixed_atoms])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added functions to create double, single right and single left screw dislocation kinks in BCC materials. Also added a function to slice a long dislocation configuration into many 1 b thick configurations for dislocation structure and core position analysis.  Corresponding tests are added as well.