### PR TITLE
BUG: reversed pairs not correctly determined

### DIFF
--- a/matscipy/calculators/eam/calculator.py
+++ b/matscipy/calculators/eam/calculator.py
@@ -36,7 +36,7 @@ except:
     InterpolatedUnivariateSpline = None
 
 from matscipy.calculators.eam.io import read_eam
-from matscipy.neighbours import neighbour_list
+from matscipy.neighbours import neighbour_list, find_indices_of_reversed_pairs
 
 ###
 
@@ -52,33 +52,6 @@ def _make_derivative(x):
     else:
         return x.derivative()
 
-def _find_indices_of_reverse_pairs(i_n, j_n):
-    """Find array position where reverse pair is stored.
-
-    For an array of atom identifiers, find the 
-    array of indices :code:`reverse`, such that 
-    :code:`i_n[x] = j_n[reverse[x]]` and
-    :code:`j_n[x] = i_n[reverse[x]]`
-
-    Parameters
-    ----------
-    i_n : array_like
-       array of atom identifiers
-    j_n : array_like
-       array of atom identifiers
-
-    Returns
-    -------
-    reverse : numpy.ndarray
-        array of indices into i_n and j_n
-    """
-    sorted_1 = np.lexsort(keys=(i_n, j_n))
-    sorted_2 = np.lexsort(keys=(j_n, i_n))
-    tmp2 = np.arange(i_n.size)[sorted_2]
-    tmp1 = np.arange(i_n.size)[sorted_1]
-    reverse  = np.empty(i_n.size, dtype=i_n.dtype)
-    reverse[tmp1] = tmp2
-    return reverse
 
 ###
 
@@ -200,7 +173,7 @@ class EAM(Calculator):
                 demb_i[mask] += dF(density_i[mask])
 
         # Forces
-        reverse = _find_indices_of_reverse_pairs(i_n, j_n)
+        reverse = find_indices_of_reversed_pairs(i_n, j_n, abs_dr_n)
         df_i_n = np.take(df_n, reverse)
         df_nc = -0.5*((demb_i[i_n]*df_n+demb_i[j_n]*df_i_n)+drep_n).reshape(-1,1)*dr_nc/abs_dr_n.reshape(-1,1)
 

--- a/matscipy/neighbours.py
+++ b/matscipy/neighbours.py
@@ -245,3 +245,49 @@ e_nc = (dr_nc.T/abs_dr_n).T
     return _matscipy.neighbour_list(quantities, cell_origin, cell,
                                     np.linalg.inv(cell.T), pbc, positions,
                                     _cutoff, numbers)
+
+
+def find_indices_of_reversed_pairs(i_n, j_n, abs_dr_n):
+    """Find neighbor list indices where reversed pairs are stored
+
+    Given list of identifiers of neighbor atoms `i_n` and `j_n`,
+    determines the list of indices `reverse` into the neighbor list
+    where each pair is reversed, i.e. `i_n[reverse[n]]=j_n[n]` and
+    `j_n[reverse[n]]=i_n[n]` for each index `n` in the neighbor list
+    
+    In the case of small periodic systems, one needs to be careful, because
+    the same pair may appear more than one time, with different pair
+    distances. Therefore, the pair distance must be taken into account.
+
+    We assume that there is in fact one reversed pair for every pair.
+    However, we do not check this assumption in order to avoid overhead.
+
+    Parameters
+    ----------
+    i_n : array_like
+       array of atom identifiers
+    j_n : array_like
+       array of atom identifiers
+    abs_dr_n : array_like
+        pair distances
+
+    Returns
+    -------
+    reverse : numpy.ndarray
+        array of indices into i_n and j_n
+    """
+    sorted_1 = np.lexsort(keys=(abs_dr_n, i_n, j_n))
+    sorted_2 = np.lexsort(keys=(abs_dr_n, j_n, i_n))
+    #np.testing.assert_equal(j_n[sorted_1], i_n[sorted_2])
+    #np.testing.assert_equal(i_n[sorted_1], j_n[sorted_2])
+    #np.testing.assert_equal(abs_dr_n[sorted_1], abs_dr_n[sorted_2])
+    #print(np.c_[i_n[sorted_2], j_n[sorted_2], abs_dr_n[sorted_2], 
+    #            i_n[sorted_1], j_n[sorted_1], abs_dr_n[sorted_1]])
+    tmp2 = np.arange(i_n.size)[sorted_2]
+    tmp1 = np.arange(i_n.size)[sorted_1]
+    # np.arange(i_n.size) are indices into the neighbor list, so
+    #  * the nth element in tmp1 is the index where i,j was before reordering with sorted_1
+    #  * the nth element in tmp2 is the index where j,i was before reordering with sorted_2
+    reverse = np.empty(i_n.size, dtype=i_n.dtype)
+    reverse[tmp1] = tmp2
+    return reverse


### PR DESCRIPTION
In small periodic systems, the reversed pair (j,i)
for atom pair (i,j) was not correctly identified
because (i,j) and (j,i) appear more than once in
the neighbor list, with different distances.

Moved the corresponding function from the EAM
calculator to neighbors.py, since it is
independent of EAM.

I think this should solve #30. 
```
import matscipy
from matscipy import calculators as msp_calculators
from ase import calculators as ase_calculators
import ase
from ase.lattice.cubic import BodyCenteredCubic
import numpy as np

latticeconstant = 2.855
size = (3, 3, 3)
atoms = BodyCenteredCubic(
    directions=[(1, 0, 0), (0, 1, 0), (0, 0, 1)],
    size=size,
    symbol="Fe",
    pbc=True,
    latticeconstant=latticeconstant,
)
atoms.append(ase.Atom("H", (0.0, latticeconstant * 0.25, latticeconstant * 0.5)))
msp_calc = msp_calculators.eam.EAM("PotentialB.fs", kind="eam/fs")
ase_calc = ase_calculators.calculator.get_calculator_class("eam")(
    potential="PotentialB.fs"
)
atoms.set_calculator(msp_calc)
e1 = atoms.get_potential_energy()
f1 = atoms.get_forces()
atoms.set_calculator(ase_calc)
e2 = atoms.get_potential_energy()
f2 = atoms.get_forces()
print(e1 - e2)
print(np.max(f1 - f2))
```
Gives:
> 2.842170943040401e-14
> 1.865885224106023e-10