### PR TITLE
Removed constrain on system size in EAM Hessian calculation.

### DIFF
--- a/tests/eam_calculator_forces_and_hessian.py
+++ b/tests/eam_calculator_forces_and_hessian.py
@@ -108,7 +108,28 @@ class TestEAMForcesHessian(matscipytest.MatSciPyTestCase):
         Reference: finite difference approximation of 
         Hessian from ASE
         """
-        atoms = FaceCenteredCubic('Cu', size=[4, 4, 4])
+        def _test_for_size(size):
+            atoms = FaceCenteredCubic('Cu', size=size)
+            calculator = EAM('CuAg.eam.alloy')
+            self._test_hessian(atoms, calculator)
+        _test_for_size(size=[1, 1, 1])
+        _test_for_size(size=[2, 2, 2])
+        _test_for_size(size=[1, 4, 4])
+        _test_for_size(size=[4, 1, 4])
+        _test_for_size(size=[4, 4, 1])
+        _test_for_size(size=[4, 4, 4])
+
+    def test_hessian_monoatomic_with_duplicate_pairs(self):
+        """Calculate Hessian matrix of pure Cu
+
+        In a small system, the same pair (i,j) will
+        appear multiple times in the neighbor list,
+        with different pair distance.
+
+        Reference: finite difference approximation of 
+        Hessian from ASE
+        """
+        atoms = FaceCenteredCubic('Cu', size=[2, 2, 2])
         calculator = EAM('CuAg.eam.alloy')
         self._test_hessian(atoms, calculator)
 


### PR DESCRIPTION
It is now possible to calculate the EAM Hessian also for
small periodic systems, where atom pairs (i,j) appear more
than one time in the neighbor list, with different entries
corresponding to different pair distances.

The EAM Hessian requires a list of common neighbors of
atom pairs. Construction of this list is independent of
EAM; therefore I have added it as a standalone method
to matscipy.neighbors.

@jameskermode, this commit should fix #38 