### PR TITLE
ENH: reduce memory consumption during calculation of the Hessian matrix of EAM atoms

### DIFF
--- a/matscipy/calculators/eam/calculator.py
+++ b/matscipy/calculators/eam/calculator.py
@@ -217,7 +217,6 @@ class EAM(Calculator):
                         'stress': virial_v/self.atoms.get_volume(),
                         'forces': forces_ic}
 
-    @profile
     def calculate_hessian_matrix(self, atoms, divide_by_masses=False):
         r"""Compute the Hessian matrix
 
@@ -560,7 +559,6 @@ class EAM(Calculator):
         D += bsr_matrix((Ddiag, np.arange(nat), np.arange(nat+1)), shape=(3*nat, 3*nat))
         return D
     
-    @profile
     def _calculate_hessian_embedding_term_1(self, nat, ddemb_i, df_e_ni, 
         divide_by_masses=False, masses_i=None, symmetry_check=False):
         """Calculate term 1 in the embedding part of the Hessian matrix.


### PR DESCRIPTION
I have modified the EAM calculator to reduce peak memory consumption during construction of the Hessian matrix. 
The Hessian consists of a pair term plus eight embedding energy terms. Previously, all were calculated in one method.
Memory of temporary variables was not released before the end of the method. Now the different terms are calculated 
in separate methods, hence temporary memory is released earlier. I have also revised calculation of the expensive 
eighth embedding energy term.

I have tested the revised implementation with a system of 50933 atoms. The Hessian matrix has size 152799 × 152799.
The previous version has a peak memory consumption of approx. 55 GB, the current version needs 14GB.