### PR TITLE
BUG: electron density and charge functions in EAM kind 'eam' interchanged

### DIFF
--- a/matscipy/calculators/eam/io.py
+++ b/matscipy/calculators/eam/io.py
@@ -187,8 +187,8 @@ def read_eam(eam_file, kind="eam/alloy"):
             raise ValueError(f"expected {expected_length} tabulated values, but there are {true_length}")
         data = np.array(remaining_words, dtype=float)
         F = data[0:Nrho]
-        f = data[Nrho:Nrho+Nr]
-        rep = data[Nrho+Nr:2*Nr+Nrho]
+        rep = data[Nrho:Nrho+Nr]
+        f = data[Nrho+Nr:2*Nr+Nrho]
         return source, parameters, F, f, rep
 
     if kind in ["eam/alloy", "eam/fs"]:


### PR DESCRIPTION
In an EAM table of kind 'eam' (DYNAMO funcfl format), the effective
charge function comes before the electron density function, see
https://lammps.sandia.gov/doc/pair_eam.html

In the current version of `matscipy.calculators.eam.io.read_eam`,
`f` contains the charge function, and `rep` the electron density
function.

The bug was introduced in the initial commit
9bc3fa918aa03c60f6a59f3231ec9ba05fc13893