### PR TITLE
BUG: `f` and `rep` interchanged in `write_eam` in case `kind=='eam'`

### DIFF
--- a/matscipy/calculators/eam/io.py
+++ b/matscipy/calculators/eam/io.py
@@ -529,11 +529,11 @@ def write_eam(source, parameters, F, f, rep, out_file, kind="eam"):
         # --- Writing new EAM alloy pot file --- #
         # write header and file parameters
         potfile = open(out_file,'wb')
-        # write F and f tables
+        # write F and pair charge tables
         np.savetxt(potfile, F, fmt='%.16e', header=potheader, comments='')
-        np.savetxt(potfile, f, fmt='%.16e')
-        # write pair interactions tables
         np.savetxt(potfile, rep, fmt='%.16e')
+        # write electron density tables
+        np.savetxt(potfile, f, fmt='%.16e')
         potfile.close()  
     elif kind == "eam/alloy":
         num_elements = len(elements)

--- a/tests/test_eam_io.py
+++ b/tests/test_eam_io.py
@@ -55,24 +55,24 @@ class TestEAMIO(matscipytest.MatSciPyTestCase):
 
     tol = 1e-6
 
-    # def test_eam_read_write(self):
-    #     source,parameters,F,f,rep = read_eam("Au_u3.eam",kind="eam")
-    #     write_eam(source,parameters,F,f,rep,"Au_u3_copy.eam",kind="eam")
-    #     source1,parameters1,F1,f1,rep1 = read_eam("Au_u3_copy.eam",kind="eam")
-    #     os.remove("Au_u3_copy.eam")
-    #     for i,p in enumerate(parameters):
-    #         try:
-    #             diff = p - parameters1[i]
-    #         except:
-    #             diff = None
-    #         if diff is None:
-    #             self.assertTrue(p == parameters1[i])
-    #         else:
-    #             print(i, p, parameters1[i], diff, self.tol, diff < self.tol)
-    #             self.assertTrue(diff < self.tol)
-    #     self.assertTrue((F == F1).all())
-    #     self.assertTrue((f == f1).all())
-    #     self.assertTrue((rep == rep1).all())
+    def test_eam_read_write(self):
+        source,parameters,F,f,rep = read_eam("Au_u3.eam",kind="eam")
+        write_eam(source,parameters,F,f,rep,"Au_u3_copy.eam",kind="eam")
+        source1,parameters1,F1,f1,rep1 = read_eam("Au_u3_copy.eam",kind="eam")
+        os.remove("Au_u3_copy.eam")
+        for i,p in enumerate(parameters):
+            try:
+                diff = p - parameters1[i]
+            except:
+                diff = None
+            if diff is None:
+                self.assertTrue(p == parameters1[i])
+            else:
+                print(i, p, parameters1[i], diff, self.tol, diff < self.tol)
+                self.assertTrue(diff < self.tol)
+        self.assertTrue((F == F1).all())
+        self.assertTrue((f == f1).all())
+        self.assertTrue((rep == rep1).all())
     
     def test_eam_alloy_read_write(self):
         source,parameters,F,f,rep = read_eam("CuAgNi_Zhou.eam.alloy",kind="eam/alloy")


### PR DESCRIPTION
In EAM potential tables of kind `eam`, the pair charge function `rep`
comes before the electron density function `f`. Up until recently,
they were read in the wrong order in `matscipy.calculators.eam.io.read_eam`.
The issue was fixed in commit 704b1be3f8f0402a5591641479d41e30ad255591.
However, the order had not been not corrected in
`matscipy.calculators.eam.io.write_eam`, hence a test in
`test_eam_io.py` failed.

This commit should fix issue #60. 
I have re-enabled the test. 

Note that the eam-style is still wrong, see #54.