### PR TITLE
BUGFIX: Pair potential in eam kind 'eam' (funcfl format) was wrong

### DIFF
--- a/matscipy/calculators/eam/io.py
+++ b/matscipy/calculators/eam/io.py
@@ -550,7 +550,8 @@ def write_eam(source, parameters, F, f, rep, out_file, kind="eam"):
     if kind == "eam":
         # parameters unpacked
         # FIXME: atomic numbers etc are now arrays, and not scalars
-        atline = f"{int(atomic_numbers)} {float(atomic_masses)}  {float(lattice_parameters)} {str(crystal_structures)}"
+        crystal_structures_str = ' '.join(s for s in crystal_structures)
+        atline = f"{int(atomic_numbers)} {float(atomic_masses)}  {float(lattice_parameters)} {crystal_structures_str}"
         parameterline = f'{int(Nrho)}\t{float(drho):.16e}\t{int(Nr)}\t{float(dr):.16e}\t{float(cutoff):.10e}'
         potheader = f"# EAM potential from : # {source} \n {atline} \n {parameterline}"
         # --- Writing new EAM alloy pot file --- #

--- a/tests/test_eam_io.py
+++ b/tests/test_eam_io.py
@@ -72,7 +72,7 @@ class TestEAMIO(matscipytest.MatSciPyTestCase):
                 self.assertTrue(diff < self.tol)
         self.assertTrue((F == F1).all())
         self.assertTrue((f == f1).all())
-        self.assertTrue((rep == rep1).all())
+        self.assertArrayAlmostEqual(rep, rep1)
     
     def test_eam_alloy_read_write(self):
         source,parameters,F,f,rep = read_eam("CuAgNi_Zhou.eam.alloy",kind="eam/alloy")


### PR DESCRIPTION
This PR addresses #54.

EAM tables of kind `eam` (DYNAMO funcfl format) contain the effective charge
function `z_i`, rather than the pair potential `phi_ij`. The pair potential for
elements `i` and `j` can be calculated from the charge functions as
`r*phi_ij=z_i z_j`, see https://lammps.sandia.gov/doc/pair_eam.html. An
additional prefactor `27.2*0.529` is necessary in order to convert to units of
electronvolt.

Previously, the tabulated data was used directly, i.e. z_i was used as the pair
potential.

This commit adds the required conversion from `z` to `phi` in
matscipy/calculators/eam/io.py.

I have implemented the same unit conversion factors that are used in Lammps,
but one could also use the more precise estimates in `ase.units.Hartree` and
`ase.units.Bohr`.

I replaced the test for strict equality in test_eam_io.py to allow small
floating point errors that occur when converting `z_i` back and forth.

To test the revised code, I calculated the potential energy per atom of 
a Face-Centered Cubic Au crystal as a function of lattice parameter, 
for [Foiles' 'universal 3' potential](https://www.ctcms.nist.gov/potentials/Download/1986--Foiles-S-M-Baskes-M-I-Daw-M-S--Ag-Au-Cu-Ni-Pd-Pt/1/Au_u3.eam). 

I performed the calculation with Lammps, with the TabulatedEAM 
calculator from atomistica, and with matscipy with different choices
of the interpolating splines from scipy.interpolate.

The figure on the left shows the difference with respect to the Lammps
result. The difference between the matscipy results and the Lammps
results is close to zero around 4 (close to the 0K lattice parameter), 
but increases at large lattice parameter. However, this is 
most likely a consequence of the use of different splines. in Lammps
and matscipy. The embedding energy `F` of the Foiles potential does 
not go smoothly to zero as the electron density `rho` goes to zero (see 
the figure on the right), which should have an effect on the splines. 
This region of `F` becomes relevant at low density / large lattice 
parameter. So, in conclusion, I'm confident that the matscipy 
implementation is now correct.

![epot_differences](https://user-images.githubusercontent.com/15941035/99828061-bf367400-2b5a-11eb-9c99-f2101ab2e3b2.png)
