### PR TITLE
Fix GitHub's language detection by excluding '.fs' files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 matscipy/_version.py export-subst
+*.fs -linguist-detectable


### PR DESCRIPTION
I noticed that GitHub reports this project to be 87% implemented in Forth. GitHub reports this because of the 8.87 MB [w_eam4.fs](https://github.com/libAtoms/matscipy/blob/281a1715ce459a1c38b76d958709153e3dd75c28/tests/w_eam4.fs) test file which has an extension that suggests it is written in Forth.

Here is the breakdown before my change:
![matscipy-before](https://user-images.githubusercontent.com/31571242/109832760-aab05000-7c0e-11eb-99ba-8ee0c19a5a3b.png)

And here is the breakdown after:
![matscipy-after](https://user-images.githubusercontent.com/31571242/109832758-aab05000-7c0e-11eb-8fe0-99b5f3a0aba9.png)