### PR TITLE
Splitting BKS pair potential from Ewald summation

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,9 +3,12 @@ name: Run tests
 on:
   push:
     branches:
-      - '*'
+      - '**'
     tags:
-      - '*'
+      - '**'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   tests:

--- a/matscipy/calculators/eam/calculator.py
+++ b/matscipy/calculators/eam/calculator.py
@@ -61,7 +61,7 @@ def _make_derivative(x, n=1):
 ###
 
 class EAM(Calculator):
-    implemented_properties = ['energy', 'stress', 'forces']
+    implemented_properties = ['energy', 'free_energy', 'stress', 'forces']
     default_parameters = {}
     name = 'EAM'
        

--- a/matscipy/calculators/ewald/__init__.py
+++ b/matscipy/calculators/ewald/__init__.py
@@ -21,4 +21,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from .calculator import BKSEwald, Ewald
+from .calculator import Ewald

--- a/matscipy/calculators/ewald/calculator.py
+++ b/matscipy/calculators/ewald/calculator.py
@@ -34,131 +34,93 @@ Pair potential + Ewald summation
 
 import numpy as np
 
-from scipy.sparse import bsr_matrix
-
 from scipy.linalg import block_diag
-
-from scipy.sparse.linalg import cg
-
 from scipy.special import erfc
 
-import ase
-
-from ase.calculators.calculator import Calculator
-
-from ...neighbours import neighbour_list, first_neighbours, mic
-from ...numpy_tricks import mabincount
-from ...elasticity import Voigt_6_to_full_3x3_stress
-
-###
+from ...calculators.pair_potential.calculator import (
+    PairPotential, CutoffInteraction
+)
 
 # Charges q are expressed as multiples of the elementary charge e: q = x*e
-# e^2/(4*pi*epsilon0) = 14.399645 eV * Angström 
+# e^2/(4*pi*epsilon0) = 14.399645 eV * Angström
 conversion_prefactor = 14.399645
 
-###
 
-class BKSEwald:
-    """
-    Beest, Kramer, van Santen (BKS) potential.
-    Functional form is Buckingham + Coulomb potential
+class EwaldShortRange(CutoffInteraction):
+    """Short range term of Ewald summation."""
 
-    Buckingham:  
-        Energy is shifted to zero at the cutoff.
-    Coulomb:   
-        Electrostatic interaction is treated using the traditional Ewald summation.
-                     
-    References
-    ----------
-    B. W. Van Beest, G. J. Kramer and R. A. Van Santen, Phys. Rev. Lett. 64.16 (1990)
-    """
-
-    def __init__(self, A, B, C, alpha, cutoff_r, cutoff_k, nb_kspace, accuracy):
-        self.A = A
-        self.B = B 
-        self.C = C
+    def __init__(self, alpha, cutoff):
+        super().__init__(cutoff)
         self.alpha = alpha
-        self.cutoff_r = cutoff_r
-        self.cutoff_k = cutoff_k
-        self.nb_kspace = nb_kspace
-        self.accuracy = accuracy
 
-        # Expression for shifting energy
-        self.buck_offset_energy = A * np.exp(-B * cutoff_r) - C / cutoff_r**6
+    def __call__(self, r, qi, qj):
+        return conversion_prefactor * qi * qj * erfc(self.alpha * r) / r
 
-    def get_nb_kspace(self):
-        """
-        Return triplet of integers defining maximal number of reciprocal points
-        """
-        return self.nb_kspace
+    def first_derivative(self, r, qi, qj):
+        a = self.alpha
+        return -conversion_prefactor * qi * qj \
+            * (erfc(a * r) / r**2
+               + 2 * a * np.exp(-((a * r)**2)) / (np.sqrt(np.pi)*r))
 
-    def get_alpha(self):
-        return self.alpha
+    def second_derivative(self, r, qi, qj):
+        a = self.alpha
+        return conversion_prefactor * qi * qj \
+            * (2 * erfc(a * r) / r**3
+               + 4 * a * np.exp((-(a * r)**2))
+               / np.sqrt(np.pi) * (1 / r**2 + a**2))
 
-    def get_cutoff_real(self):
-        """
-        Cutoff radius for the short range interaction
-        """
-        return self.cutoff_r
-
-    def get_cutoff_kspace(self):
-        """
-        Cutoff wave vector in reciprocal space
-        """
-        return self.cutoff_k
-
-    def get_accuracy(self):
-        """
-        Accuracy in reciprocal space 
-        """
-        return self.accuracy
-        
-    def energy_rspace(self, r, pair_charge, a):
-        """
-        Potential
-        """
-        E_buck = self.A * np.exp(-self.B * r) - self.C / r**6 - self.buck_offset_energy 
-        E_coul = conversion_prefactor * pair_charge * erfc(a * r) / r
-
-        return E_buck + E_coul
-
-    def first_derivative_rspace(self, r, pair_charge, a):
-        """
-        First derivative
-        """
-        f_buck = -self.A * self.B * np.exp(-self.B * r) + 6 * self.C / r**7 
-        f_coul = -conversion_prefactor * pair_charge * (erfc(a * r) / r**2
-                  + 2 * a * np.exp(-((a * r)**2)) / (np.sqrt(np.pi)*r))
-
-        return f_buck + f_coul
-
-    def second_derivative_rspace(self, r, pair_charge, a):
-        """
-        Second derivative 
-        """
-        k_buck = self.A * self.B**2 * np.exp(-self.B * r) - 42 * self.C / r**8
-        k_coul = conversion_prefactor * pair_charge * (2 * erfc(a * r) / r**3
-                 + 4 * a * np.exp((-(a * r)**2)) / np.sqrt(np.pi) * (1 / r**2 + a**2))
-
-        return k_buck + k_coul
-
-###
-
-class Ewald(Calculator):
+class Ewald(PairPotential):
     implemented_properties = ["energy", "free_energy", "stress", "forces", "hessian"]
-    default_parameters = {}
+    default_parameters = {'accuracy': 1e-6, 'cutoff': 10, 'verbose': True}
     name = 'Ewald'
 
-    def __init__(self, f, cutoff=None):
-        Calculator.__init__(self)
-        self.f = f
-        self.initial_cell = None
+    def __init__(self):
+        super().__init__({
+            (1, 1): EwaldShortRange(None, None)
+        })
+
+        self.set(**self.parameters)
         self.kvectors = None
+        self.initial_cell = None
         self.initial_I = None
         self.initial_alpha = None
-        self.dict = {x: obj.get_cutoff_real() for x, obj in f.items()}
 
-    def determine_alpha(self, charge, acc, cutoff, cell):
+    @property
+    def alpha(self):
+        """Get alpha."""
+        return self._alpha
+
+    @alpha.setter
+    def alpha(self, v):
+        """Set alpha."""
+        self._alpha = v
+        self.f[(1, 1)].alpha = v
+
+    @property
+    def cutoff(self):
+        """Short range cutoff."""
+        return self.f[(1, 1)].cutoff
+
+    @cutoff.setter
+    def cutoff(self, v):
+        self.f[(1, 1)].cutoff = v
+        super().reset()
+
+    def set(self, **kwargs):
+        super().set(**kwargs)
+
+        if 'cutoff' in kwargs:
+            self.cutoff = kwargs['cutoff']
+
+        if 'accuracy' in kwargs:
+            self.reset()
+
+    def _mask_pairs(self, i_p, j_p):
+        """Match all atom types to the (1, 1) object for pair interactions."""
+        yield None, (1, 1)
+
+    @staticmethod
+    def determine_alpha(charge, acc, cutoff, cell):
         """
         Determine an estimate for alpha on the basis of the cell, cutoff and desired accuracy
         (Adopted from LAMMPS)
@@ -170,18 +132,20 @@ class Ewald(Calculator):
 
         qsqsum = conversion_prefactor * np.sum(charge**2)
 
-        a = accuracy_relative * np.sqrt(len(charge) * cutoff * cell[0,0] * cell[1, 1] * cell[2, 2]) / (2 * qsqsum)
-        
+        a = accuracy_relative * np.sqrt(len(charge) * cutoff
+                                        * cell[0, 0] * cell[1, 1] * cell[2, 2]) / (2 * qsqsum)
+
         if a >= 1.0:
             return (1.35 - 0.15 * np.log(accuracy_relative)) / cutoff
 
         else:
             return np.sqrt(-np.log(a)) / cutoff
 
-    def determine_nk(self, charge, c, cell, acc, a, natoms):
+    @staticmethod
+    def determine_nk(charge, cell, acc, a, natoms):
         """
         Determine the maximal number of points in reciprocal space for each direction,
-        and the cutoff in reciprocal space 
+        and the cutoff in reciprocal space
         """
 
         # The kspace rms error is computed relative to the force that two unit point
@@ -191,28 +155,28 @@ class Ewald(Calculator):
         nxmax = 1
         nymax = 1
         nzmax = 1
-     
+
         qsqsum = conversion_prefactor * np.sum(charge**2)
 
-        error = c.rms_kspace(nxmax, cell[0, 0], natoms, a, qsqsum)
+        error = Ewald.rms_kspace(nxmax, cell[0, 0], natoms, a, qsqsum)
         while error > (accuracy_relative):
             nxmax += 1
-            error = c.rms_kspace(nxmax, cell[0, 0], natoms, a, qsqsum)
+            error = Ewald.rms_kspace(nxmax, cell[0, 0], natoms, a, qsqsum)
 
-        error = c.rms_kspace(nymax, cell[1, 1], natoms, a, qsqsum)
+        error = Ewald.rms_kspace(nymax, cell[1, 1], natoms, a, qsqsum)
         while error > (accuracy_relative):
             nymax += 1
-            error = c.rms_kspace(nymax, cell[1, 1], natoms, a, qsqsum)
+            error = Ewald.rms_kspace(nymax, cell[1, 1], natoms, a, qsqsum)
 
-        error = c.rms_kspace(nzmax, cell[2, 2], natoms, a, qsqsum)
+        error = Ewald.rms_kspace(nzmax, cell[2, 2], natoms, a, qsqsum)
         while error > (accuracy_relative):
             nzmax += 1
-            error = c.rms_kspace(nzmax, cell[2, 2], natoms, a, qsqsum)
+            error = Ewald.rms_kspace(nzmax, cell[2, 2], natoms, a, qsqsum)
 
         kxmax = 2 * np.pi / cell[0, 0] * nxmax
         kymax = 2 * np.pi / cell[1, 1] * nymax
         kzmax = 2 * np.pi / cell[2, 2] * nzmax
-        
+
         kmax = max(kxmax, kymax, kzmax)
 
         # Check if box is triclinic --> Scale lattice vectors for triclinic skew
@@ -225,7 +189,8 @@ class Ewald(Calculator):
 
         return kmax, np.array([nxmax, nymax, nzmax])
 
-    def determine_kc(self, cell, nk):
+    @staticmethod
+    def determine_kc(cell, nk):
         """
         Determine maximal wave vector based in a given integer triplet
         """
@@ -235,70 +200,76 @@ class Ewald(Calculator):
 
         return max(kxmax, kymax, kzmax)
 
-    def rms_kspace(self, km, l, n, a, q2):
+    @staticmethod
+    def rms_kspace(km, l, n, a, q2):
         """
         Compute the root mean square error of the force in reciprocal space
-        
+
         Reference
         ------------------
         Henrik G. Petersen, The Journal of chemical physics 103.9 (1995)
         """
 
-        return 2 * q2 * a / l * np.sqrt(1 / (np.pi * km * n)) * np.exp(-(np.pi * km / (a * l))**2) 
+        return 2 * q2 * a / l * np.sqrt(1 / (np.pi * km * n)) * np.exp(-(np.pi * km / (a * l))**2)
 
-    def rms_rspace(self, charge, cell, a, rc):
+    @staticmethod
+    def rms_rspace(charge, cell, a, rc):
         """
         Compute the root mean square error of the force in real space
-        
+
         Reference
         ------------------
         Henrik G. Petersen, The Journal of chemical physics 103.9 (1995)
         """
 
         return 2 * np.sum(charge**2) * np.exp(-(a * rc)**2) / np.sqrt(rc * len(charge) * cell[0,0] * cell[1, 1] * cell[2, 2])
- 
-    def allowed_wave_vectors(self, cell, km, a, nk):
+
+    @staticmethod
+    def allowed_wave_vectors(cell, km, a, nk):
         """
-        Compute allowed wave vectors and the prefactor I 
+        Compute allowed wave vectors and the prefactor I
         """
         nx = np.arange(-nk[0], nk[0]+1, 1)
         ny = np.arange(-nk[1], nk[1]+1, 1)
-        nz = np.arange(-nk[2], nk[2]+1, 1) 
-   
-        n_lc = np.array(np.meshgrid(nx, ny, nz)).T.reshape(-1,3)
-        
+        nz = np.arange(-nk[2], nk[2]+1, 1)
+
+        n_lc = np.array(np.meshgrid(nx, ny, nz)).T.reshape(-1, 3)
+
         k_lc = 2 * np.pi * np.dot(np.linalg.inv(np.array(cell)), n_lc.T).T
-        
+
         k = np.linalg.norm(k_lc, axis=1)
-        
+
         mask = np.logical_and(k <= km, k != 0)
 
         return np.exp(-(k[mask] / (2 * a))**2) / k[mask]**2, k_lc[mask]
 
-    def self_energy(self, charge, a):
+    @staticmethod
+    def self_energy(charge, a):
         """
         Return the self energy
         """
         return -conversion_prefactor * a * np.sum(charge**2) / np.sqrt(np.pi)
 
-    def kspace_energy(self, charge, pos, vol, I, k):
+    @staticmethod
+    def kspace_energy(charge, pos, vol, I, k):
         """
         Return the energy from the reciprocal space contribution
         """
 
-        structure_factor_l = np.sum(charge * np.exp(1j * np.tensordot(k, pos, axes=((1),(1)))), axis=1)
+        structure_factor_l = \
+            np.sum(charge * np.exp(1j * np.tensordot(k, pos, axes=((1),(1)))), axis=1)
 
-        return conversion_prefactor * 2 * np.pi * np.sum(I * np.absolute(structure_factor_l)**2) / vol
+        return conversion_prefactor * 2 * np.pi \
+            * np.sum(I * np.absolute(structure_factor_l)**2) / vol
 
-    def first_derivative_kspace(self, charge, natoms, vol, pos, I, k):
-        """
-        Return the kspace part of the force 
-        """
+    @staticmethod
+    def first_derivative_kspace(charge, natoms, vol, pos, I, k):
+        """Return the kspace part of the force."""
         n = len(pos)
 
         phase_ln = np.tensordot(k, pos, axes=((1),(1)))
 
-        cos_ln = np.cos(phase_ln) 
+        cos_ln = np.cos(phase_ln)
         sin_ln = np.sin(phase_ln)
 
         cos_sin_ln = (cos_ln.T * np.sum(charge * sin_ln, axis=1)).T
@@ -310,20 +281,22 @@ class Ewald(Calculator):
 
         return -conversion_prefactor * 4 * np.pi * (charge * f_nc.T).T / vol
 
-    def stress_kspace(self, charge, pos, vol, a, I, k):
-        """
-        Return the stress contribution of the long-range Coulomb part
-        """
-        sqk_l = np.sum(k * k, axis=1) 
+    @staticmethod
+    def stress_kspace(charge, pos, vol, a, I, k):
+        """Return the stress contribution of the long-range Coulomb part."""
+        sqk_l = np.sum(k * k, axis=1)
 
-        structure_factor_l = np.sum(charge * np.exp(1j * np.tensordot(k, pos, axes=((1),(1)))), axis=1)
+        structure_factor_l = \
+            np.sum(charge * np.exp(1j * np.tensordot(k, pos, axes=((1),(1)))), axis=1)
 
-        wave_vectors_lcc = (k.reshape(-1, 3, 1) * k.reshape(-1, 1, 3)) * (1 / (2 * a**2) + 2 / sqk_l).reshape(-1, 1, 1) - np.identity(3)
+        wave_vectors_lcc = (k.reshape(-1, 3, 1) * k.reshape(-1, 1, 3)) \
+            * (1 / (2 * a**2) + 2 / sqk_l).reshape(-1, 1, 1) - np.identity(3)
 
-        stress_lcc = (I * np.absolute(structure_factor_l)**2).reshape(len(I), 1, 1) * wave_vectors_lcc
-        
+        stress_lcc = (I * np.absolute(structure_factor_l)**2).reshape(len(I), 1, 1) \
+            * wave_vectors_lcc
+
         stress_cc = np.sum(stress_lcc, axis=0)
-        
+
         stress_cc *= (conversion_prefactor * 2 * np.pi / vol)
 
         return np.array([stress_cc[0, 0],        # xx
@@ -333,312 +306,104 @@ class Ewald(Calculator):
                          stress_cc[0, 2],        # xz
                          stress_cc[0, 1]])       # xy
 
+    def reset_kspace(self, atoms):
+        """Reset kspace setup."""
+        if not atoms.has("charge"):
+            raise AttributeError(
+                "Unable to load atom charges from atoms object!")
+
+        charge_n = atoms.get_array("charge")
+
+        if np.sum(charge_n) > 1e-3:
+            print("Net charge: ", np.sum(charge_n))
+            raise AttributeError(
+                "System is not charge neutral!")
+
+        if not all(atoms.get_pbc()):
+            raise AttributeError(
+                "This code only works for 3D systems with periodic boundaries!")
+
+        accuracy, rc = self.parameters['accuracy'], self.parameters['cutoff']
+        kc = rc
+
+        self.initial_cell = atoms.get_cell()
+        self.alpha = self.determine_alpha(charge_n, accuracy, rc,
+                                          atoms.get_cell())
+
+        alpha = self.alpha
+        nb_atoms = len(atoms)
+        kc, nbk_c = self.determine_nk(charge_n,
+                                      atoms.get_cell(), accuracy, alpha,
+                                      nb_atoms)
+
+        if np.all(nbk_c) is None and kc is None:
+            kc = self.determine_kc(atoms.get_cell(), nbk_c)
+
+        self.initial_alpha = alpha
+
+        I_l, k_lc = self.allowed_wave_vectors(atoms.get_cell(), kc,
+                                              alpha, nbk_c)
+
+        self.kvectors = k_lc
+        self.initial_I = I_l
+
+        # Priting info
+        if self.parameters.get('verbose'):
+            rms_rspace = self.rms_rspace(charge_n, atoms.get_cell(), alpha, rc)
+            rms_kspace = [
+                self.rms_kspace(nbk_c[i], atoms.get_cell()[i, i],
+                                nb_atoms, alpha,
+                                conversion_prefactor * np.sum(charge_n**2))
+                for i in range(3)]
+
+            print("Estimated alpha: ", alpha)
+            print("Number of wave vectors: ", k_lc.shape[0])
+            print("Cutoff for kspace vectors: ", kc)
+            print("Estimated kspace triplets nx/ny/nx: ", nbk_c[0], "/",
+                  nbk_c[1], "/", nbk_c[2])
+            print("Estimated absolute RMS force accuracy (Real space): ",
+                  np.absolute(rms_rspace))
+            print("Estimated absolute RMS force accuracy (Kspace): ",
+                  np.linalg.norm(rms_kspace))
 
     def calculate(self, atoms, properties, system_changes):
-        Calculator.calculate(self, atoms, properties, system_changes)
+        """Compute Coulomb interactions with Ewald summation."""
+        if 'cell' in system_changes or self.atoms is None:
+            self.reset()
+            self.reset_kspace(atoms)
 
-        nb_atoms = len(self.atoms)
-        atnums = self.atoms.numbers
-        atnums_in_system = set(atnums)
+        super().calculate(atoms, properties, system_changes)
 
-        if atoms.has("charge"):
-            charge_n = self.atoms.get_array("charge")
-        else:
-            raise AttributeError(
-                "Attribute error: Unable to load atom charges from atoms object!")
+        nb_atoms = len(atoms)
+        charge_n = atoms.get_array('charge')
 
-        if np.sum(charge_n) > 1e-3:
-            print("Net charge: ", np.sum(charge_n))
-            raise AttributeError(
-                "Attribute error: System is not charge neutral!")      
+        k_lc = self.kvectors
+        I_l = self.initial_I
+        alpha = self.initial_alpha
 
-        if not any(self.atoms.get_pbc()):
-            raise AttributeError(
-                "Attribute error: This code only works for 3D systems with periodic boundaries!")    
-
-        for index, pairs in enumerate(self.f.values()):
-            if index == 0:
-                alpha = pairs.get_alpha()
-                rc = pairs.get_cutoff_real()
-                kc = pairs.get_cutoff_kspace()
-                nbk_c = pairs.get_nb_kspace()
-                accuracy = pairs.get_accuracy()
-            else:
-                if ((rc != pairs.get_cutoff_real()) 
-                     or (kc != pairs.get_cutoff_kspace()) 
-                     or (alpha != pairs.get_alpha()) 
-                     or (accuracy != pairs.get_accuracy())):
-                    raise AttributeError(
-                        "Attribute error: Cannot use different rc, kc, number of wave vectors or accuracy!")     
-
-
-        # If cell has changed --> Recompute wave vectors, parameters and errors
-        if np.all(self.initial_cell == None):
-
-            self.initial_cell = atoms.get_cell()
-
-            if alpha == None:
-                alpha = self.determine_alpha(charge_n, accuracy, rc, atoms.get_cell())
-
-            if np.any(nbk_c) == None:
-                kc, nbk_c = self.determine_nk(charge_n, atoms.get_calculator(), atoms.get_cell(), accuracy, alpha, nb_atoms)    
-
-            if np.all(nbk_c) != None and kc == None:
-                kc = self.determine_kc(atoms.get_cell(), nbk_c)
-
-            self.initial_alpha = alpha 
-
-            I_l, k_lc = self.allowed_wave_vectors(atoms.get_cell(), kc, alpha, nbk_c)
-
-            self.kvectors = k_lc
-            self.initial_I = I_l
-
-            # 
-            rms_rspace = self.rms_rspace(charge_n, atoms.get_cell(), alpha, rc)
-            rms_kspace_x = self.rms_kspace(nbk_c[0], atoms.get_cell()[0, 0], nb_atoms, alpha, conversion_prefactor * np.sum(charge_n**2))
-            rms_kspace_y = self.rms_kspace(nbk_c[1], atoms.get_cell()[1, 1], nb_atoms, alpha, conversion_prefactor * np.sum(charge_n**2))
-            rms_kspace_z = self.rms_kspace(nbk_c[2], atoms.get_cell()[2, 2], nb_atoms, alpha, conversion_prefactor * np.sum(charge_n**2))
-
-            print("Estimated alpha: ", alpha)
-            print("Number of wave vectors: ", k_lc.shape[0])
-            print("Cutoff for kspace vectors: ", kc)
-            print("Estimated kspace triplets nx/ny/nx: ", nbk_c[0], "/", nbk_c[1], "/", nbk_c[2]) 
-            print("Estimated absolute RMS force accuracy (Real space): ", np.absolute(rms_rspace))
-            print("Estimated absolute RMS force accuracy (Kspace): ", np.sqrt(rms_kspace_x**2 + rms_kspace_y**2 + rms_kspace_z**2))
-
-        elif np.any(self.initial_cell != atoms.get_cell()):
-
-            self.initial_cell = atoms.get_cell()
-
-            if alpha == None:
-                alpha = self.determine_alpha(charge_n, accuracy, rc, atoms.get_cell())
-
-            if np.any(nbk_c) == None:
-                kc, nbk_c = self.determine_nk(charge_n, atoms.get_calculator(), atoms.get_cell(), accuracy, alpha, nb_atoms)    
-
-            if np.all(nbk_c) != None and kc == None:
-                kc = self.determine_kc(atoms.get_cell(), nbk_c)
-
-            self.initial_alpha = alpha 
-
-            # Prefactor and wave vectors for reciprocal space 
-            I_l, k_lc = self.allowed_wave_vectors(atoms.get_cell(), kc, alpha, nbk_c)
-
-            self.kvectors = k_lc
-            self.initial_I = I_l
-
-            # Compute and print error estimates and kspace parameters
-            rms_rspace = self.rms_rspace(charge_n, atoms.get_cell(), alpha, rc)
-            rms_kspace_x = self.rms_kspace(nbk_c[0], atoms.get_cell()[0, 0], nb_atoms, alpha, conversion_prefactor * np.sum(charge_n**2))
-            rms_kspace_y = self.rms_kspace(nbk_c[1], atoms.get_cell()[1, 1], nb_atoms, alpha, conversion_prefactor * np.sum(charge_n**2))
-            rms_kspace_z = self.rms_kspace(nbk_c[2], atoms.get_cell()[2, 2], nb_atoms, alpha, conversion_prefactor * np.sum(charge_n**2))
-
-            print("Estimated alpha: ", alpha)
-            print("Number of wave vectors: ", k_lc.shape[0])
-            print("Cutoff for kspace vectors: ", kc)
-            print("Estimated kspace triplets nx/ny/nx: ", nbk_c[0], "/", nbk_c[1], "/", nbk_c[2]) 
-            print("Estimated absolute RMS force accuracy (Real space): ", np.absolute(rms_rspace))
-            print("Estimated absolute RMS force accuracy (Kspace): ", np.sqrt(rms_kspace_x**2 + rms_kspace_y**2 + rms_kspace_z**2))
-
-        elif np.all(self.initial_cell == atoms.get_cell()):
-            k_lc = self.kvectors
-            I_l = self.initial_I
-            alpha = self.initial_alpha
-
-        # Neighbor list for short range interaction
-        i_p, j_p, r_p, r_pc = neighbour_list('ijdD', self.atoms, self.dict)
-        chargeij = charge_n[i_p] * charge_n[j_p]
-
-        if np.sum(i_p == j_p) > 1e-5:
-            print("Atoms can see themselves!")
-
-        # Short-range interaction of Buckingham and Ewald
-        e_p = np.zeros_like(r_p)
-        de_p = np.zeros_like(r_p)
-        for params, pair in enumerate(self.dict):
-            if pair[0] == pair[1]:
-                mask1 = atnums[i_p] == pair[0]
-                mask2 = atnums[j_p] == pair[0]
-                mask = np.logical_and(mask1, mask2)
-
-                e_p[mask] = self.f[pair].energy_rspace(r_p[mask], chargeij[mask], alpha)
-                de_p[mask] = self.f[pair].first_derivative_rspace(r_p[mask], chargeij[mask], alpha)
-
-            if pair[0] != pair[1]:
-                mask1 = np.logical_and(
-                    atnums[i_p] == pair[0], atnums[j_p] == pair[1])
-                mask2 = np.logical_and(
-                    atnums[i_p] == pair[1], atnums[j_p] == pair[0])
-                mask = np.logical_or(mask1, mask2)
-
-                e_p[mask] = self.f[pair].energy_rspace(r_p[mask], chargeij[mask], alpha)
-                de_p[mask] = self.f[pair].first_derivative_rspace(r_p[mask], chargeij[mask], alpha)
-
-
-        # Energy 
+        # Energy
         e_self = self.self_energy(charge_n, alpha)
-
-        e_long = self.kspace_energy(charge_n, atoms.get_positions(), atoms.get_volume(), I_l, k_lc)
-
-        epot = 0.5 * np.sum(e_p) + e_self + e_long 
+        e_long = self.kspace_energy(charge_n, atoms.get_positions(),
+                                    atoms.get_volume(), I_l, k_lc)
+        self.results['energy'] += e_self + e_long
+        self.results['free_energy'] = self.results['energy']
 
         # Forces
-        df_pc = -0.5 * de_p.reshape(-1, 1) * r_pc / r_p.reshape(-1, 1) 
-
-        f_nc = mabincount(j_p, df_pc, nb_atoms) - mabincount(i_p, df_pc, nb_atoms)
-
-        f_nc += self.first_derivative_kspace(charge_n, nb_atoms, atoms.get_volume(), atoms.get_positions(), I_l, k_lc)
+        self.results['forces'] += self.first_derivative_kspace(
+            charge_n, nb_atoms, atoms.get_volume(),
+            atoms.get_positions(), I_l, k_lc
+        )
 
         # Virial
-        virial_v = -np.array([r_pc[:, 0] * df_pc[:, 0],               # xx
-                              r_pc[:, 1] * df_pc[:, 1],               # yy
-                              r_pc[:, 2] * df_pc[:, 2],               # zz
-                              r_pc[:, 1] * df_pc[:, 2],               # yz
-                              r_pc[:, 0] * df_pc[:, 2],               # xz
-                              r_pc[:, 0] * df_pc[:, 1]]).sum(axis=1)  # xy
-
-        virial_v += self.stress_kspace(charge_n, atoms.get_positions(), atoms.get_volume(), alpha, I_l, k_lc) 
-
-        self.results = {'energy': epot,
-                        'free_energy': epot,
-                        'stress': virial_v/self.atoms.get_volume(),
-                        'forces': f_nc}
-
-    ###
-
-    def hessian_rspace(self, atoms, format='sparse', divide_by_masses=False):
-        """
-        Calculate the Hessian matrix for the short range part.
-
-        Parameters
-        ----------
-        atoms: ase.Atoms
-            Atomic configuration in a local or global minima.
-
-        format: "dense" or "neighbour-list"
-            Output format of the hessian matrix.
-
-        divide_by_masses: bool
-            if true return the dynamical matrix else the Hessian matrix 
-
-        Restrictions
-        ----------
-        This method is currently only implemented for three dimensional systems
-        """
-
-        f = self.f
-        nb_atoms = len(atoms)
-        atnums = atoms.numbers
-
-        if atoms.has("charge"):
-            charge_n = atoms.get_array("charge")
-        else:
-            raise AttributeError(
-                "Attribute error: Unable to load atom charges from atoms object!")
-
-        if np.sum(charge_n) > 1e-3:
-            print("Net charge: ", np.sum(charge_n))
-            raise AttributeError(
-                "Attribute error: System is not charge neutral!")      
-
-        if not any(atoms.get_pbc()):
-            raise AttributeError(
-                "Attribute error: This code only works for 3D systems with periodic boundaries!")    
-
-        for index, pairs in enumerate(self.f.values()):
-            if index == 0:
-                alpha = pairs.get_alpha()
-                rc = pairs.get_cutoff_real()
-                accuracy = pairs.get_accuracy()
-            else:
-                if ((rc != pairs.get_cutoff_real()) 
-                     or (alpha != pairs.get_alpha()) 
-                     or (accuracy != pairs.get_accuracy())):
-                    raise AttributeError(
-                         "Attribute error: Cannot use different rc, number of wave vectors or accuracy!")   
-
-        if alpha == None:
-            alpha = self.determine_alpha(charge_n, accuracy, rc, atoms.get_cell())
-
-        print("Rspace parameters:")
-        print("----------------------------")
-        print("Estimated alpha: ", alpha)
-
-        i_p, j_p, r_p, r_pc = neighbour_list('ijdD', atoms, self.dict)
-        chargeij = charge_n[i_p] * charge_n[j_p]
-        first_i = first_neighbours(nb_atoms, i_p)
-
-        if np.sum(i_p == j_p) > 1e-5:
-            print("Atoms can see themselves!")
-
-        de_p = np.zeros_like(r_p)
-        dde_p = np.zeros_like(r_p)
-        for params, pair in enumerate(self.dict):
-            if pair[0] == pair[1]:
-                mask1 = atnums[i_p] == pair[0]
-                mask2 = atnums[j_p] == pair[0]
-                mask = np.logical_and(mask1, mask2)
-
-                de_p[mask] = f[pair].first_derivative_rspace(r_p[mask], chargeij[mask], alpha)
-                dde_p[mask] = f[pair].second_derivative_rspace(r_p[mask], chargeij[mask], alpha)
-
-            if pair[0] != pair[1]:
-                mask1 = np.logical_and(
-                    atnums[i_p] == pair[0], atnums[j_p] == pair[1])
-                mask2 = np.logical_and(
-                    atnums[i_p] == pair[1], atnums[j_p] == pair[0])
-                mask = np.logical_or(mask1, mask2)
-
-                de_p[mask] = f[pair].first_derivative_rspace(r_p[mask], chargeij[mask], alpha)
-                dde_p[mask] = f[pair].second_derivative_rspace(r_p[mask], chargeij[mask], alpha)
-        
-        n_pc = (r_pc.T / r_p).T
-        H_pcc = -(dde_p * (n_pc.reshape(-1, 3, 1)
-                           * n_pc.reshape(-1, 1, 3)).T).T
-        H_pcc += -(de_p / r_p * (np.eye(3, dtype=n_pc.dtype)
-                                    - (n_pc.reshape(-1, 3, 1) * n_pc.reshape(-1, 1, 3))).T).T
-
-        # Sparse BSR-matrix
-        if format == "sparse":
-            if divide_by_masses:
-                masses_n = atoms.get_masses()
-                geom_mean_mass_p = np.sqrt(masses_n[i_p]*masses_n[j_p])
-
-            if divide_by_masses:
-                H = bsr_matrix(((H_pcc.T/geom_mean_mass_p).T, j_p, first_i), shape=(3*nb_atoms, 3*nb_atoms))
-
-            else: 
-                H = bsr_matrix((H_pcc, j_p, first_i), shape=(3*nb_atoms, 3*nb_atoms))
-
-            Hdiag_icc = np.empty((nb_atoms, 3, 3))
-            for x in range(3):
-                for y in range(3):
-                    Hdiag_icc[:, x, y] = - \
-                        np.bincount(i_p, weights=H_pcc[:, x, y])
-
-            if divide_by_masses:
-                H += bsr_matrix(((Hdiag_icc.T/masses_n).T, np.arange(nb_atoms),
-                             np.arange(nb_atoms+1)), shape=(3*nb_atoms, 3*nb_atoms))
-
-            else:
-                H += bsr_matrix((Hdiag_icc, np.arange(nb_atoms),
-                             np.arange(nb_atoms+1)), shape=(3*nb_atoms, 3*nb_atoms))
-
-            return H
-
-        # Neighbour list format
-        elif format == "neighbour-list":
-            return H_pcc, i_p, j_p, r_pc, r_p
-
-        else:
-           raise AttributeError(
-                "Attribute error: Can not return a Hessian matrix using the given format!")                
-
-    ###
+        self.results['stress'] += self.stress_kspace(
+            charge_n, atoms.get_positions(), atoms.get_volume(),
+            alpha, I_l, k_lc
+        )
 
     def kspace_properties(self, atoms, prop="Hessian", divide_by_masses=False):
         """
-        Calculate the recirprocal contributiom to the Hessian, the non-affine forces and the Born elastic constants
+        Calculate the recirprocal contributiom to the Hessian, the non-affine
+        forces and the Born elastic constants
 
         Parameters
         ----------
@@ -646,76 +411,23 @@ class Ewald(Calculator):
             Atomic configuration in a local or global minima.
 
         prop: "Hessian", "Born" or "Naforces"
-            Compute either the Hessian/Dynamical matrix, the Born constants 
+            Compute either the Hessian/Dynamical matrix, the Born constants
             or the non-affine forces.
 
         divide_by_masses: bool
-            if true return the dynamic matrix else Hessian matrix 
+            if true return the dynamic matrix else Hessian matrix
 
         Restrictions
         ----------
         This method is currently only implemented for three dimensional systems
         """
-        f = self.f
         nb_atoms = len(atoms)
+        alpha = self.alpha
+        k_lc = self.kvectors
+        I_l = self.initial_I
+        charge_n = atoms.get_array("charge")
 
-        if atoms.has("charge"):
-            charge_n = atoms.get_array("charge")
-        else:
-            raise AttributeError(
-                "Attribute error: Unable to load atom charges from atoms object!")
-
-        if np.sum(charge_n) > 1e-3:
-            print("Net charge: ", np.sum(charge_n))
-            raise AttributeError(
-                "Attribute error: System is not charge neutral!")      
-
-        if not any(atoms.get_pbc()):
-            raise AttributeError(
-                "Attribute error: This code only works for 3D systems with periodic boundaries!")    
-
-        for index, pairs in enumerate(self.f.values()):
-            if index == 0:
-                alpha = pairs.get_alpha()
-                rc = pairs.get_cutoff_real()
-                kc = pairs.get_cutoff_kspace()
-                nbk_c = pairs.get_nb_kspace()
-                accuracy = pairs.get_accuracy()
-            else:
-                if ((rc != pairs.get_cutoff_real()) 
-                     or (kc != pairs.get_cutoff_kspace()) 
-                     or (alpha != pairs.get_alpha()) 
-                     or (accuracy != pairs.get_accuracy())):
-                    raise AttributeError(
-                        "Attribute error: Cannot use different rc, kc, number of wave vectors or accuracy!")  
-
-        if alpha == None:
-            alpha = self.determine_alpha(charge_n, accuracy, rc, atoms.get_cell())
-
-        if np.any(nbk_c) == None:
-            kc, nbk_c = self.determine_nk(charge_n, atoms.get_calculator(), atoms.get_cell(), accuracy, alpha, nb_atoms)    
-
-        if np.all(nbk_c) != None and kc == None:
-            kc = self.determine_kc(atoms.get_cell(), nbk_c)
-
-        I_l, k_lc = self.allowed_wave_vectors(atoms.get_cell(), kc, alpha, nbk_c)
-
-        # Compute and print error estimates
-        rms_rspace = self.rms_rspace(charge_n, atoms.get_cell(), alpha, rc)
-        rms_kspace_x = self.rms_kspace(nbk_c[0], atoms.get_cell()[0, 0], nb_atoms, alpha, conversion_prefactor*np.sum(charge_n**2))
-        rms_kspace_y = self.rms_kspace(nbk_c[1], atoms.get_cell()[1, 1], nb_atoms, alpha, conversion_prefactor*np.sum(charge_n**2))
-        rms_kspace_z = self.rms_kspace(nbk_c[2], atoms.get_cell()[2, 2], nb_atoms, alpha, conversion_prefactor*np.sum(charge_n**2))
-
-        print("Kspace parameters:")
-        print("----------------------------")
-        print("Estimated alpha: ", alpha)
-        print("Number of wave vectors: ", k_lc.shape[0])
-        print("Cutoff for kspace vectors: ", kc)
-        print("Estimated kspace vectors nx/ny/nx: ", nbk_c[0], "/", nbk_c[1], "/", nbk_c[2]) 
-        print("Estimated absolute RMS force accuracy (Real space): ", np.absolute(rms_rspace))
-        print("Estimated absolute RMS force accuracy (Kspace): ", np.sqrt(rms_kspace_x**2 + rms_kspace_y**2 + rms_kspace_z**2))
-
-        if prop == "Hessian":  
+        if prop == "Hessian":
             H = np.zeros((3*nb_atoms, 3*nb_atoms))
 
             pos = atoms.get_positions()
@@ -723,7 +435,7 @@ class Ewald(Calculator):
             for i, k in enumerate(k_lc):
                 phase_l = np.sum(k * pos, axis=1)
 
-                I_sqcos_sqsin = I_l[i] * (np.cos(phase_l).reshape(-1, 1) * np.cos(phase_l).reshape(1, -1) + 
+                I_sqcos_sqsin = I_l[i] * (np.cos(phase_l).reshape(-1, 1) * np.cos(phase_l).reshape(1, -1) +
                                           np.sin(phase_l).reshape(-1, 1) * np.sin(phase_l).reshape(1, -1))
 
                 I_sqcos_sqsin[range(nb_atoms), range(nb_atoms)] = 0.0
@@ -735,7 +447,7 @@ class Ewald(Calculator):
             Hdiag = np.zeros((3*nb_atoms, 3))
             for x in range(3):
                 Hdiag[:, x] = -np.sum(H[:,x::3], axis=1)
-         
+
             Hdiag = block_diag(*Hdiag.reshape(nb_atoms, 3, 3))
 
             H += Hdiag
@@ -744,11 +456,11 @@ class Ewald(Calculator):
                 masses_p = (atoms.get_masses()).repeat(3)
                 H /= np.sqrt(masses_p.reshape(-1, 1)*masses_p.reshape(1, -1))
 
-            return H 
+            return H
 
         elif prop == "Born":
             delta_ab = np.identity(3)
-            sqk_l = np.sum(k_lc * k_lc, axis=1) 
+            sqk_l = np.sum(k_lc * k_lc, axis=1)
 
             structure_factor_l = np.sum(charge_n * np.exp(1j * np.tensordot(k_lc, atoms.get_positions(), axes=((1),(1)))), axis=1)
             prefactor_l = (I_l * np.absolute(structure_factor_l)**2).reshape(-1, 1, 1, 1, 1)
@@ -757,7 +469,7 @@ class Ewald(Calculator):
             first_abab = delta_ab.reshape(1, 3, 3, 1, 1) * delta_ab.reshape(1, 1, 1, 3, 3) + \
                          delta_ab.reshape(1, 1, 3, 3, 1) * delta_ab.reshape(1, 3, 1, 1, 3)
 
-            # Second expression 
+            # Second expression
             prefactor_second_l = -(1 / (2 * alpha**2) + 2 / sqk_l).reshape(-1, 1, 1, 1, 1)
             second_labab = k_lc.reshape(-1, 1, 1, 3, 1) * k_lc.reshape(-1, 1, 1, 1, 3) * delta_ab.reshape(1, 3, 3, 1, 1) + \
                            k_lc.reshape(-1, 3, 1, 1, 1) * k_lc.reshape(-1, 1, 1, 3, 1) * delta_ab.reshape(1, 1, 3, 1, 3) + \
@@ -775,11 +487,11 @@ class Ewald(Calculator):
 
         elif prop == "Naforces":
             delta_ab = np.identity(3)
-            sqk_l = np.sum(k_lc * k_lc, axis=1) 
+            sqk_l = np.sum(k_lc * k_lc, axis=1)
 
             phase_ln = np.tensordot(k_lc, atoms.get_positions(), axes=((1),(1)))
 
-            cos_ln = np.cos(phase_ln) 
+            cos_ln = np.cos(phase_ln)
             sin_ln = np.sin(phase_ln)
 
             cos_sin_ln = (cos_ln.T * np.sum(charge_n * sin_ln, axis=1)).T
@@ -789,28 +501,26 @@ class Ewald(Calculator):
 
             # First expression
             first_lccc = (1 / (2 * alpha**2) + 2 / sqk_l).reshape(-1, 1, 1, 1) * \
-                         k_lc.reshape(-1, 1, 1, 3) * k_lc.reshape(-1, 3, 1, 1) * k_lc.reshape(-1, 1, 3, 1)
-                         
+                k_lc.reshape(-1, 1, 1, 3) * k_lc.reshape(-1, 3, 1, 1) * k_lc.reshape(-1, 1, 3, 1)
+
             # Second expression
-            second_lccc = -(k_lc.reshape(-1, 3, 1, 1) * delta_ab.reshape(-1, 1, 3, 3) + 
+            second_lccc = -(k_lc.reshape(-1, 3, 1, 1) * delta_ab.reshape(-1, 1, 3, 3) +
                             k_lc.reshape(-1, 1, 3, 1) * delta_ab.reshape(-1, 3, 1, 3))
 
             naforces_nccc = np.sum(prefactor_ln.reshape(-1, nb_atoms, 1, 1, 1) * (first_lccc + second_lccc).reshape(-1, 1, 3, 3, 3), axis=0)
 
             return -conversion_prefactor * 4 * np.pi * (charge_n * naforces_nccc.T).T / atoms.get_volume()
 
-    ###
-
-    def get_hessian(self, atoms):
+    def get_hessian(self, atoms, format=""):
         """
         Compute the real space + kspace Hessian
         """
-        H = self.hessian_rspace(atoms, format="sparse").todense()
-        H += self.kspace_properties(atoms, prop="Hessian")
+        # Ignore kspace here
+        if format == 'neighbour-list':
+            return super().get_hessian(atoms, format=format)
 
-        return H
-
-    ###
+        return super().get_hessian(atoms, format="sparse").todense() \
+            + self.kspace_properties(atoms, prop="Hessian")
 
     def get_nonaffine_forces(self, atoms):
         """
@@ -822,24 +532,12 @@ class Ewald(Calculator):
             Atomic configuration in a local or global minima.
 
         """
-
-        nat = len(atoms)
-
-        # Rspace 
-        H_pcc, i_p, j_p, dr_pc, abs_dr_p = self.hessian_rspace(atoms, "neighbour-list")
-        naF_pcab = -0.5 * H_pcc.reshape(-1, 3, 3, 1) * dr_pc.reshape(-1, 1, 1, 3)
-        naforces_icab = mabincount(i_p, naF_pcab, nat) - mabincount(j_p, naF_pcab, nat)
-
-        # Kspace
-        naforces_icab += self.kspace_properties(atoms, prop="Naforces")
-
-        return naforces_icab  
-
-    ###
+        return super().get_nonaffine_forces(atoms) \
+            + self.kspace_properties(atoms, prop="Naforces")
 
     def get_born_elastic_constants(self, atoms):
         """
-        Compute the Born elastic constants. 
+        Compute the Born elastic constants.
 
         Parameters
         ----------
@@ -847,197 +545,24 @@ class Ewald(Calculator):
             Atomic configuration in a local or global minima.
 
         """
-        # Contribution from real space 
-        H_pcc, i_p, j_p, dr_pc, abs_dr_p = self.hessian_rspace(atoms, "neighbour-list")
-
-        # Real space contribution
-        C_pabab = H_pcc.reshape(-1, 3, 1, 3, 1) * dr_pc.reshape(-1, 1, 3, 1, 1) * dr_pc.reshape(-1, 1, 1, 1, 3)
-        C_abab = -C_pabab.sum(axis=0) / (2*atoms.get_volume())
-
-        # Reciprocal space contribution
-        C_abab += self.kspace_properties(atoms, prop="Born")
+        C_abab = super().get_born_elastic_constants(atoms) \
+            + self.kspace_properties(atoms, prop="Born")
 
         # Symmetrize elastic constant tensor
-        C_abab = (C_abab + C_abab.swapaxes(0, 1) + C_abab.swapaxes(2, 3) + C_abab.swapaxes(0, 1).swapaxes(2, 3)) / 4
+        C_abab = (C_abab + C_abab.swapaxes(0, 1) + C_abab.swapaxes(2, 3)
+                  + C_abab.swapaxes(0, 1).swapaxes(2, 3)) / 4
 
         return C_abab
-
-    ###
-
-    def get_stress_contribution_to_elastic_constants(self, atoms):
-        """
-        Compute the correction to the elastic constants due to non-zero stress in the configuration.
-        Stress term  results from working with the Cauchy stress.
-
-        Parameters
-        ----------
-        atoms: ase.Atoms
-            Atomic configuration in a local or global minima.
-
-        """
-        
-        stress_ab = Voigt_6_to_full_3x3_stress(atoms.get_stress())
-        delta_ab = np.identity(3)
-
-        # Term 1
-        C1_abab = -stress_ab.reshape(3, 3, 1, 1) * delta_ab.reshape(1, 1, 3, 3)
-        C1_abab = (C1_abab + C1_abab.swapaxes(0, 1) + C1_abab.swapaxes(2, 3) + C1_abab.swapaxes(0, 1).swapaxes(2, 3)) / 4
-
-        # Term 2
-        C2_abab = (stress_ab.reshape(3, 1, 1, 3) * delta_ab.reshape(1, 3, 3, 1) + \
-                   stress_ab.reshape(3, 1, 3, 1) * delta_ab.reshape(1, 3, 1, 3) + \
-                   stress_ab.reshape(1, 3, 1, 3) * delta_ab.reshape(3, 1, 3, 1) + \
-                   stress_ab.reshape(1, 3, 3, 1) * delta_ab.reshape(3, 1, 1, 3))/4
-
-        return C1_abab + C2_abab
-    
-    ###
-
-    def get_birch_coefficients(self, atoms):
-        """
-        Compute the Birch coefficients (Effective elastic constants at non-zero stress). 
-        
-        Parameters
-        ----------
-        atoms: ase.Atoms
-            Atomic configuration in a local or global minima.
-
-        """
-        if self.atoms is None:
-            self.atoms = atoms
-
-        # Born (affine) elastic constants
-        calculator = atoms.get_calculator()
-        bornC_abab = calculator.get_born_elastic_constants(atoms)
-
-        # Stress contribution to elastic constants
-        stressC_abab = calculator.get_stress_contribution_to_elastic_constants(atoms)
-
-        return bornC_abab + stressC_abab
-
-    ###
-
-    def get_non_affine_contribution_to_elastic_constants(self, atoms, eigenvalues=None, eigenvectors=None, pc_parameters=None, cg_parameters={"x0": None, "tol": 1e-5, "maxiter": None, "M": None, "callback": None, "atol": 1e-5}):
-        """
-        Compute the correction of non-affine displacements to the elasticity tensor.
-        The computation of the occuring inverse of the Hessian matrix is bypassed by using a cg solver.
-
-        If eigenvalues and and eigenvectors are given the inverse of the Hessian can be easily computed.
-
-        Parameters
-        ----------
-        atoms: ase.Atoms
-            Atomic configuration in a local or global minima.
-
-        eigenvalues: array
-            Eigenvalues in ascending order obtained by diagonalization of Hessian matrix.
-            If given, use eigenvalues and eigenvectors to compute non-affine contribution. 
-
-        eigenvectors: array
-            Eigenvectors corresponding to eigenvalues.
-
-        cg_parameters: dict
-            Dictonary for the conjugate-gradient solver.
-
-            x0: {array, matrix}
-                Starting guess for the solution.
-
-            tol/atol: float, optional
-                Tolerances for convergence, norm(residual) <= max(tol*norm(b), atol).
-
-            maxiter: int
-                Maximum number of iterations. Iteration will stop after maxiter steps even if the specified tolerance has not been achieved.
-
-            M: {sparse matrix, dense matrix, LinearOperator}
-                Preconditioner for A.
-                
-            callback: function  
-                User-supplied function to call after each iteration.
-
-        pc_parameters: dict
-            Dictonary for the incomplete LU decomposition of the Hessian.
-
-            A: array_like
-                Sparse matrix to factorize.
-
-            drop_tol: float
-                Drop tolerance for an incomplete LU decomposition.
-
-            fill_factor: float
-                Specifies the fill ratio upper bound.
-
-            drop_rule: str
-                Comma-separated string of drop rules to use.
-
-            permc_spec: str
-                How to permute the columns of the matrix for sparsity.
-
-            diag_pivot_thresh: float
-                Threshold used for a diagonal entry to be an acceptable pivot.
-
-            relax: int
-                Expert option for customizing the degree of relaxing supernodes.
-
-            panel_size: int
-                Expert option for customizing the panel size.
-
-            options: dict 
-                Dictionary containing additional expert options to SuperLU.
-        """
-
-        nat = len(atoms)
-
-        calc = atoms.get_calculator()    
-
-        if (eigenvalues is not None) and (eigenvectors is not None):
-            naforces_icab = calc.get_nonaffine_forces(atoms)
-
-            G_incc = (eigenvectors.T).reshape(-1, 3*nat, 1, 1) * naforces_icab.reshape(1, 3*nat, 3, 3)
-            G_incc = (G_incc.T / np.sqrt(eigenvalues)).T
-            G_icc  = np.sum(G_incc, axis=1)
-            C_abab = np.sum(G_icc.reshape(-1,3,3,1,1) * G_icc.reshape(-1,1,1,3,3), axis=0)
-
-        else:
-            H_nn = calc.get_hessian(atoms)
-            naforces_icab = calc.get_nonaffine_forces(atoms)
-
-            if pc_parameters != None:
-                # Transform H to csc 
-                H_nn = H_nn.tocsc()
-
-                # Compute incomplete LU 
-                approx_Hinv = spilu(H_nn, **pc_parameters)
-                operator_Hinv = LinearOperator(H_nn.shape, approx_Hinv.solve)
-                cg_parameters["M"] = operator_Hinv
-
-            D_iab = np.zeros((3*nat, 3, 3))
-            for i in range(3):
-                for j in range(3):
-                    x, info = cg(H_nn, naforces_icab[:, :, i, j].flatten(), **cg_parameters)
-                    if info != 0:
-                        print("info: ", info)
-                        raise RuntimeError(" info > 0: CG tolerance not achieved, info < 0: Exceeded number of iterations.")
-                    D_iab[:,i,j] = x
-
-            C_abab = np.sum(naforces_icab.reshape(3*nat, 3, 3, 1, 1) * D_iab.reshape(3*nat, 1, 1, 3, 3), axis=0)
-        
-        # Symmetrize 
-        C_abab = (C_abab + C_abab.swapaxes(0, 1) + C_abab.swapaxes(2, 3) + C_abab.swapaxes(0, 1).swapaxes(2, 3)) / 4             
-
-        return -C_abab / atoms.get_volume()
-
-    ###
 
     def get_derivative_volume(self, atoms, d=1e-6):
         """
         Calculate the change of volume with strain using central differences
         """
-        nat = len(atoms)
         cell = atoms.cell.copy()
-        vol = np.zeros((3,3))
+        vol = np.zeros((3, 3))
 
         for i in range(3):
-            # Diagonal 
+            # Diagonal
             x = np.eye(3)
             x[i, i] += d
             atoms.set_cell(np.dot(cell, x), scale_atoms=True)
@@ -1067,33 +592,30 @@ class Ewald(Calculator):
             vol[i, j] = derivative_volume
             vol[j, i] = derivative_volume
 
-
         return vol
-
-    ###
 
     def get_derivative_wave_vector(self, atoms, d=1e-6):
         """
         Calculate the change of volume with strain using central differences
         """
-        nat = len(atoms)
         cell = atoms.cell.copy()
-        
-        initial_k = 2 * np.pi * np.dot(np.linalg.inv(cell), np.array([1,1,1]))
+
+        e = np.ones(3)
+        initial_k = 2 * np.pi * np.dot(np.linalg.inv(cell), e)
         print("Wave vector for n=(1,1,1): ", initial_k)
 
-        def_k = np.zeros((3,3,3))
+        def_k = np.zeros((3, 3, 3))
 
         for i in range(3):
-            # Diagonal 
+            # Diagonal
             x = np.eye(3)
             x[i, i] += d
             atoms.set_cell(np.dot(cell, x), scale_atoms=True)
-            k_pos = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), np.array([1,1,1]))
+            k_pos = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), e)
 
             x[i, i] -= 2 * d
             atoms.set_cell(np.dot(cell, x), scale_atoms=True)
-            k_minus = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), np.array([1,1,1]))
+            k_minus = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), e)
             derivative_k = (k_pos - k_minus) / (2 * d)
             def_k[:, i, i] = derivative_k
 
@@ -1101,12 +623,11 @@ class Ewald(Calculator):
             j = i - 2
             x[i, j] = d
             atoms.set_cell(np.dot(cell, x), scale_atoms=True)
-            scaled_nbk = np.dot(np.array(np.abs(cell)), np.array([1,1,1]))
-            k_pos = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), np.array([1,1,1]))
+            k_pos = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), e)
 
             x[i, j] = -d
             atoms.set_cell(np.dot(cell, x), scale_atoms=True)
-            k_minus = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), np.array([1,1,1]))
+            k_minus = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), e)
 
             derivative_k = (k_pos - k_minus) / (2 * d)
             def_k[:, i, j] = derivative_k
@@ -1114,71 +635,13 @@ class Ewald(Calculator):
             # Odd diagonal --> yx, zx, zy
             x[j, i] = d
             atoms.set_cell(np.dot(cell, x), scale_atoms=True)
-            k_pos = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), np.array([1,1,1]))
+            k_pos = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), e)
 
             x[j, i] = -d
             atoms.set_cell(np.dot(cell, x), scale_atoms=True)
-            k_minus = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), np.array([1,1,1]))
+            k_minus = 2 * np.pi * np.dot(np.linalg.inv(atoms.get_cell()), e)
 
             derivative_k = (k_pos - k_minus) / (2 * d)
             def_k[:, j, i] = derivative_k
 
         return def_k
-
-
-    ###
-
-    def get_numerical_non_affine_forces(self, atoms, d=1e-6):
-        """
-
-        Calculate numerical non-affine forces using central finite differences.
-        This is done by deforming the box, rescaling atoms and measure the force.
-
-        Parameters
-        ----------
-        atoms: ase.Atoms
-            Atomic configuration in a local or global minima.
-
-        """
-
-        nat = len(atoms)
-        cell = atoms.cell.copy()
-        fna_ncc = np.zeros((nat, 3, 3, 3))
-
-        for i in range(3):
-            # Diagonal 
-            x = np.eye(3)
-            x[i, i] += d
-            atoms.set_cell(np.dot(cell, x), scale_atoms=True)
-            fplus = atoms.get_forces()
-
-            x[i, i] -= 2 * d
-            atoms.set_cell(np.dot(cell, x), scale_atoms=True)
-            fminus = atoms.get_forces()
-
-            naForces_ncc = (fplus - fminus) / (2 * d)
-            fna_ncc[:, 0, i, i] = naForces_ncc[:, 0]
-            fna_ncc[:, 1, i, i] = naForces_ncc[:, 1]
-            fna_ncc[:, 2, i, i] = naForces_ncc[:, 2]
-
-            # Off diagonal
-            j = i - 2
-            x[i, j] = d
-            x[j, i] = d
-            atoms.set_cell(np.dot(cell, x), scale_atoms=True)
-            fplus = atoms.get_forces()
-
-            x[i, j] = -d
-            x[j, i] = -d
-            atoms.set_cell(np.dot(cell, x), scale_atoms=True)
-            fminus = atoms.get_forces()
-
-            naForces_ncc = (fplus - fminus) / (4 * d)
-            fna_ncc[:, 0, i, j] = naForces_ncc[:, 0]
-            fna_ncc[:, 0, j, i] = naForces_ncc[:, 0]
-            fna_ncc[:, 1, i, j] = naForces_ncc[:, 1]
-            fna_ncc[:, 1, j, i] = naForces_ncc[:, 1]
-            fna_ncc[:, 2, i, j] = naForces_ncc[:, 2]
-            fna_ncc[:, 2, j, i] = naForces_ncc[:, 2]
-
-        return fna_ncc

--- a/matscipy/calculators/ewald/calculator.py
+++ b/matscipy/calculators/ewald/calculator.py
@@ -75,10 +75,6 @@ class Ewald(PairPotential):
     """Ewal summation calculator."""
 
     name = 'Ewald'
-    implemented_properties = [
-        "energy", "free_energy", "stress", "forces", "hessian",
-        "nonaffine_forces",
-    ]
 
     default_parameters = {
         'accuracy': 1e-6,

--- a/matscipy/calculators/ewald/calculator.py
+++ b/matscipy/calculators/ewald/calculator.py
@@ -131,6 +131,7 @@ class Ewald(PairPotential):
             self.reset()
 
     def reset(self):
+        super().reset()
         self.dict = defaultdict(lambda: self.short_range.cutoff)
         self.df = defaultdict(lambda: self.short_range.derivative(1))
         self.df2 = defaultdict(lambda: self.short_range.derivative(2))

--- a/matscipy/calculators/pair_potential/calculator.py
+++ b/matscipy/calculators/pair_potential/calculator.py
@@ -83,7 +83,8 @@ class CutoffInteraction(ABC):
             return self.second_derivative
         else:
             raise ValueError(
-                "Don't know how to compute {}-th derivative.".format(n))
+                "Don't know how to compute {}-th derivative.".format(n)
+            )
 
 
 class LennardJonesCut(CutoffInteraction):
@@ -96,21 +97,22 @@ class LennardJonesCut(CutoffInteraction):
         super().__init__(cutoff)
         self.epsilon = epsilon
         self.sigma = sigma
-        self.offset = (sigma/cutoff)**12 - (sigma/cutoff)**6
+        self.offset = (sigma / cutoff) ** 12 - (sigma / cutoff) ** 6
 
     def __call__(self, r, *args):
-        r6 = (self.sigma / r)**6
-        return 4 * self.epsilon * ((r6-1) * r6 - self.offset)
+        r6 = (self.sigma / r) ** 6
+        return 4 * self.epsilon * ((r6 - 1) * r6 - self.offset)
 
     def first_derivative(self, r, *args):
-        r = (self.sigma / r)
+        r = self.sigma / r
         r6 = r**6
-        return -24 * self.epsilon / self.sigma * (2*r6-1) * r6 * r
+        return -24 * self.epsilon / self.sigma * (2 * r6 - 1) * r6 * r
 
     def second_derivative(self, r, *args):
-        r2 = (self.sigma / r)**2
+        r2 = (self.sigma / r) ** 2
         r6 = r2**3
-        return 24 * self.epsilon/self.sigma**2 * (26*r6-7) * r6 * r2
+        return 24 * self.epsilon / self.sigma**2 * (26 * r6 - 7) * r6 * r2
+
 
 ###
 
@@ -125,26 +127,50 @@ class LennardJonesQuadratic(CutoffInteraction):
         super().__init__(cutoff)
         self.epsilon = epsilon
         self.sigma = sigma
-        self.offset_energy = (sigma/cutoff)**12 - (sigma/cutoff)**6
-        self.offset_force = 6/cutoff * \
-            (-2*(sigma/cutoff)**12+(sigma/cutoff)**6)
-        self.offset_dforce = (1/cutoff**2) * \
-            (156*(sigma/cutoff)**12-42*(sigma/cutoff)**6)
+        self.offset_energy = (sigma / cutoff) ** 12 - (sigma / cutoff) ** 6
+        self.offset_force = (
+            6 / cutoff * (-2 * (sigma / cutoff) ** 12 + (sigma / cutoff) ** 6)
+        )
+        self.offset_dforce = (1 / cutoff**2) * (
+            156 * (sigma / cutoff) ** 12 - 42 * (sigma / cutoff) ** 6
+        )
 
     def __call__(self, r, *args):
         """
         Return function value (potential energy).
         """
-        r6 = (self.sigma / r)**6
-        return 4 * self.epsilon * ((r6-1)*r6-self.offset_energy - (r-self.cutoff) * self.offset_force - ((r - self.cutoff)**2/2) * self.offset_dforce)
+        r6 = (self.sigma / r) ** 6
+        return (
+            4
+            * self.epsilon
+            * (
+                (r6 - 1) * r6
+                - self.offset_energy
+                - (r - self.cutoff) * self.offset_force
+                - ((r - self.cutoff) ** 2 / 2) * self.offset_dforce
+            )
+        )
 
     def first_derivative(self, r, *args):
-        r6 = (self.sigma / r)**6
-        return 4 * self.epsilon * ((6/r) * (-2*r6+1) * r6 - self.offset_force - (r-self.cutoff) * self.offset_dforce)
+        r6 = (self.sigma / r) ** 6
+        return (
+            4
+            * self.epsilon
+            * (
+                (6 / r) * (-2 * r6 + 1) * r6
+                - self.offset_force
+                - (r - self.cutoff) * self.offset_dforce
+            )
+        )
 
     def second_derivative(self, r, *args):
-        r6 = (self.sigma / r)**6
-        return 4 * self.epsilon * ((1/r**2) * (156*r6-42) * r6 - self.offset_dforce)
+        r6 = (self.sigma / r) ** 6
+        return (
+            4
+            * self.epsilon
+            * ((1 / r**2) * (156 * r6 - 42) * r6 - self.offset_dforce)
+        )
+
 
 ###
 
@@ -159,27 +185,41 @@ class LennardJonesLinear(CutoffInteraction):
         super().__init__(cutoff)
         self.epsilon = epsilon
         self.sigma = sigma
-        self.offset_energy = (sigma/cutoff)**12 - (sigma/cutoff)**6
-        self.offset_force = 6/cutoff * \
-            (-2*(sigma/cutoff)**12+(sigma/cutoff)**6)
+        self.offset_energy = (sigma / cutoff) ** 12 - (sigma / cutoff) ** 6
+        self.offset_force = (
+            6 / cutoff * (-2 * (sigma / cutoff) ** 12 + (sigma / cutoff) ** 6)
+        )
 
     def __call__(self, r, *args):
         """
         Return function value (potential energy).
         """
-        r6 = (self.sigma / r)**6
-        return 4 * self.epsilon * ((r6-1) * r6 - self.offset_energy - (r-self.cutoff) * self.offset_force)
+        r6 = (self.sigma / r) ** 6
+        return (
+            4
+            * self.epsilon
+            * (
+                (r6 - 1) * r6
+                - self.offset_energy
+                - (r - self.cutoff) * self.offset_force
+            )
+        )
 
     def first_derivative(self, r, *args):
-        r6 = (self.sigma / r)**6
-        return 4 * self.epsilon * ((6/r) * (-2*r6+1) * r6 - self.offset_force)
+        r6 = (self.sigma / r) ** 6
+        return (
+            4
+            * self.epsilon
+            * ((6 / r) * (-2 * r6 + 1) * r6 - self.offset_force)
+        )
 
     def second_derivative(self, r, *args):
-        r6 = (self.sigma / r)**6
-        return 4 * self.epsilon * ((1/r**2) * (156*r6-42) * r6)
+        r6 = (self.sigma / r) ** 6
+        return 4 * self.epsilon * ((1 / r**2) * (156 * r6 - 42) * r6)
 
 
 ###
+
 
 class FeneLJCut(LennardJonesCut):
     """
@@ -189,28 +229,33 @@ class FeneLJCut(LennardJonesCut):
     """
 
     def __init__(self, K, R0, epsilon, sigma):
-        super().__init__(2**(1/6) * sigma)
+        super().__init__(2 ** (1 / 6) * sigma)
         self.K = K
         self.R0 = R0
         self.epsilon = epsilon
         self.sigma = sigma
 
     def __call__(self, r, *args):
-        return (-0.5 * self.K * self.R0**2 * np.log(1-(r/self.R0)**2)
-                + super().__call__(r))
+        return -0.5 * self.K * self.R0**2 * np.log(
+            1 - (r / self.R0) ** 2
+        ) + super().__call__(r)
 
     def first_derivative(self, r, *args):
-        return (self.K * r / (1-(r/self.R0)**2)
-                + super().first_derivative(r))
+        return self.K * r / (
+            1 - (r / self.R0) ** 2
+        ) + super().first_derivative(r)
 
     def second_derivative(self, r, *args):
-        invLength = 1 / (1-(r/self.R0)**2)
-        return (self.K * invLength
-                + 2 * self.K * r**2 * invLength**2 / self.R0**2
-                + super().second_derivative(r))
+        invLength = 1 / (1 - (r / self.R0) ** 2)
+        return (
+            self.K * invLength
+            + 2 * self.K * r**2 * invLength**2 / self.R0**2
+            + super().second_derivative(r)
+        )
 
 
 ###
+
 
 class LennardJones84(CutoffInteraction):
     """
@@ -227,15 +272,15 @@ class LennardJones84(CutoffInteraction):
         self.C4 = C4
 
     def __call__(self, r, *args):
-        r4 = (1 / r)**4
-        return (self.C2*r4-self.C1) * r4 + self.C3 * r + self.C4
+        r4 = (1 / r) ** 4
+        return (self.C2 * r4 - self.C1) * r4 + self.C3 * r + self.C4
 
     def first_derivative(self, r, *args):
-        r4 = (1 / r)**4
-        return (-8 * self.C2*r4/r+4*self.C1/r) * r4 + self.C3
+        r4 = (1 / r) ** 4
+        return (-8 * self.C2 * r4 / r + 4 * self.C1 / r) * r4 + self.C3
 
     def second_derivative(self, r, *args):
-        r4 = (1 / r)**4
+        r4 = (1 / r) ** 4
         return (72 * self.C2 * r4 / r**2 - 20 * self.C1 / r**2) * r4
 
 
@@ -257,14 +302,19 @@ class BeestKramerSanten(CutoffInteraction):
         self.buck_offset_energy = A * np.exp(-B * cutoff) - C / cutoff**6
 
     def __call__(self, r, *args):
-        return self.A * np.exp(-self.B * r) \
-            - self.C / r**6 - self.buck_offset_energy
+        return (
+            self.A * np.exp(-self.B * r)
+            - self.C / r**6
+            - self.buck_offset_energy
+        )
 
     def first_derivative(self, r, *args):
         return -self.A * self.B * np.exp(-self.B * r) + 6 * self.C / r**7
 
     def second_derivative(self, r, *args):
-        return self.A * self.B**2 * np.exp(-self.B * r) - 42 * self.C / r**8
+        return (
+            self.A * self.B**2 * np.exp(-self.B * r) - 42 * self.C / r**8
+        )
 
 
 # Broadcast slices
@@ -273,16 +323,20 @@ _c, _cc = np.s_[..., np.newaxis], np.s_[..., np.newaxis, np.newaxis]
 
 class PairPotential(MatscipyCalculator):
     implemented_properties = [
-        'energy', 'free_energy', 'stress', 'forces',
-
-        'hessian', 'nonaffine_forces', 'birch_coefficients',
-        'nonaffine_elastic_contribution',
-        'stress_elastic_contribution',
-        'born_constants'
+        "energy",
+        "free_energy",
+        "stress",
+        "forces",
+        "hessian",
+        "nonaffine_forces",
+        "birch_coefficients",
+        "nonaffine_elastic_contribution",
+        "stress_elastic_contribution",
+        "born_constants",
     ]
 
     default_parameters = {}
-    name = 'PairPotential'
+    name = "PairPotential"
 
     class _dummy_charge:
         """Dummy object for when system has no charge."""
@@ -325,7 +379,7 @@ class PairPotential(MatscipyCalculator):
         super().calculate(atoms, properties, system_changes)
 
         nb_atoms = len(self.atoms)
-        i_p, j_p, r_p, r_pc = neighbour_list('ijdD', atoms, self.dict)
+        i_p, j_p, r_p, r_pc = neighbour_list("ijdD", atoms, self.dict)
         qi_p, qj_p = self._get_charges(i_p, j_p)
 
         e_p = np.zeros_like(r_p)
@@ -340,25 +394,36 @@ class PairPotential(MatscipyCalculator):
         # Forces
         df_pc = -0.5 * de_p[_c] * r_pc / r_p[_c]
 
-        f_nc = mabincount(j_p, df_pc, nb_atoms) \
-            - mabincount(i_p, df_pc, nb_atoms)
+        f_nc = mabincount(j_p, df_pc, nb_atoms) - mabincount(
+            i_p, df_pc, nb_atoms
+        )
 
         # Virial
-        virial_v = -np.array([r_pc[:, 0] * df_pc[:, 0],               # xx
-                              r_pc[:, 1] * df_pc[:, 1],               # yy
-                              r_pc[:, 2] * df_pc[:, 2],               # zz
-                              r_pc[:, 1] * df_pc[:, 2],               # yz
-                              r_pc[:, 0] * df_pc[:, 2],               # xz
-                              r_pc[:, 0] * df_pc[:, 1]]).sum(axis=1)  # xy
+        virial_v = -np.array(
+            [
+                r_pc[:, 0] * df_pc[:, 0],  # xx
+                r_pc[:, 1] * df_pc[:, 1],  # yy
+                r_pc[:, 2] * df_pc[:, 2],  # zz
+                r_pc[:, 1] * df_pc[:, 2],  # yz
+                r_pc[:, 0] * df_pc[:, 2],  # xz
+                r_pc[:, 0] * df_pc[:, 1],
+            ]
+        ).sum(
+            axis=1
+        )  # xy
 
-        self.results.update({'energy': epot,
-                             'free_energy': epot,
-                             'stress': virial_v / atoms.get_volume(),
-                             'forces': f_nc})
+        self.results.update(
+            {
+                "energy": epot,
+                "free_energy": epot,
+                "stress": virial_v / atoms.get_volume(),
+                "forces": f_nc,
+            }
+        )
 
     ###
 
-    def get_hessian(self, atoms, format='dense', divide_by_masses=False):
+    def get_hessian(self, atoms, format="dense", divide_by_masses=False):
         """
         Calculate the Hessian matrix for a pair potential.
         For an atomic configuration with N atoms in d dimensions the hessian matrix is a symmetric, hermitian matrix
@@ -391,7 +456,7 @@ class PairPotential(MatscipyCalculator):
 
         nb_atoms = len(atoms)
 
-        i_p, j_p,  r_p, r_pc = neighbour_list('ijdD', atoms, self.dict)
+        i_p, j_p, r_p, r_pc = neighbour_list("ijdD", atoms, self.dict)
         first_i = first_neighbours(nb_atoms, i_p)
 
         qi_p, qj_p = self._get_charges(i_p, j_p)
@@ -408,58 +473,75 @@ class PairPotential(MatscipyCalculator):
         n_pc = r_pc / r_p[_c]
         nn_pcc = n_pc[..., :, np.newaxis] * n_pc[..., np.newaxis, :]
         H_pcc = -(dde_p[_cc] * nn_pcc)
-        H_pcc += -((de_p/r_p)[_cc]
-                   * (np.eye(3, dtype=n_pc.dtype) - nn_pcc))
+        H_pcc += -((de_p / r_p)[_cc] * (np.eye(3, dtype=n_pc.dtype) - nn_pcc))
 
         # Sparse BSR-matrix
         if format == "sparse":
             if divide_by_masses:
                 masses_n = atoms.get_masses()
-                geom_mean_mass_p = np.sqrt(masses_n[i_p]*masses_n[j_p])
-                H = bsr_matrix(((H_pcc.T/geom_mean_mass_p).T, j_p, first_i), shape=(3*nb_atoms, 3*nb_atoms))
+                geom_mean_mass_p = np.sqrt(masses_n[i_p] * masses_n[j_p])
+                H = bsr_matrix(
+                    ((H_pcc.T / geom_mean_mass_p).T, j_p, first_i),
+                    shape=(3 * nb_atoms, 3 * nb_atoms),
+                )
 
             else:
-                H = bsr_matrix((H_pcc, j_p, first_i), shape=(3*nb_atoms, 3*nb_atoms))
+                H = bsr_matrix(
+                    (H_pcc, j_p, first_i), shape=(3 * nb_atoms, 3 * nb_atoms)
+                )
 
             Hdiag_icc = np.empty((nb_atoms, 3, 3))
             for x in range(3):
                 for y in range(3):
-                    Hdiag_icc[:, x, y] = - \
-                        np.bincount(i_p, weights=H_pcc[:, x, y], minlength=nb_atoms)
+                    Hdiag_icc[:, x, y] = -np.bincount(
+                        i_p, weights=H_pcc[:, x, y], minlength=nb_atoms
+                    )
 
             if divide_by_masses:
-                H += bsr_matrix(((Hdiag_icc.T/masses_n).T, np.arange(nb_atoms),
-                             np.arange(nb_atoms+1)), shape=(3*nb_atoms, 3*nb_atoms))
+                H += bsr_matrix(
+                    (
+                        (Hdiag_icc.T / masses_n).T,
+                        np.arange(nb_atoms),
+                        np.arange(nb_atoms + 1),
+                    ),
+                    shape=(3 * nb_atoms, 3 * nb_atoms),
+                )
 
             else:
-                H += bsr_matrix((Hdiag_icc, np.arange(nb_atoms),
-                             np.arange(nb_atoms+1)), shape=(3*nb_atoms, 3*nb_atoms))
+                H += bsr_matrix(
+                    (Hdiag_icc, np.arange(nb_atoms), np.arange(nb_atoms + 1)),
+                    shape=(3 * nb_atoms, 3 * nb_atoms),
+                )
 
             return H
 
         # Dense matrix format
         elif format == "dense":
-            H = np.zeros((3*nb_atoms, 3*nb_atoms))
+            H = np.zeros((3 * nb_atoms, 3 * nb_atoms))
             for atom in range(len(i_p)):
-                H[3*i_p[atom]:3*i_p[atom]+3,
-                  3*j_p[atom]:3*j_p[atom]+3] += H_pcc[atom]
+                H[
+                    3 * i_p[atom] : 3 * i_p[atom] + 3,
+                    3 * j_p[atom] : 3 * j_p[atom] + 3,
+                ] += H_pcc[atom]
 
             Hdiag_icc = np.empty((nb_atoms, 3, 3))
             for x in range(3):
                 for y in range(3):
-                    Hdiag_icc[:, x, y] = - \
-                        np.bincount(i_p, weights=H_pcc[:, x, y], minlength=nb_atoms)
+                    Hdiag_icc[:, x, y] = -np.bincount(
+                        i_p, weights=H_pcc[:, x, y], minlength=nb_atoms
+                    )
 
-            Hdiag_ncc = np.zeros((3*nb_atoms, 3*nb_atoms))
+            Hdiag_ncc = np.zeros((3 * nb_atoms, 3 * nb_atoms))
             for atom in range(nb_atoms):
-                Hdiag_ncc[3*atom:3*atom+3,
-                          3*atom:3*atom+3] += Hdiag_icc[atom]
+                Hdiag_ncc[
+                    3 * atom : 3 * atom + 3, 3 * atom : 3 * atom + 3
+                ] += Hdiag_icc[atom]
 
             H += Hdiag_ncc
 
             if divide_by_masses:
                 masses_p = (atoms.get_masses()).repeat(3)
-                H /= np.sqrt(masses_p.reshape(-1,1)*masses_p.reshape(1,-1))
+                H /= np.sqrt(masses_p.reshape(-1, 1) * masses_p.reshape(1, -1))
                 return H
 
             else:

--- a/matscipy/calculators/pair_potential/calculator.py
+++ b/matscipy/calculators/pair_potential/calculator.py
@@ -248,46 +248,43 @@ class PairPotential(MatscipyCalculator):
         MatscipyCalculator.__init__(self)
         self.f = f
 
-        self.dict = {x: obj.get_cutoff() for x, obj in f.items()}
+        self.dict = {x: obj.cutoff for x, obj in f.items()}
         self.df = {x: obj.derivative(1) for x, obj in f.items()}
         self.df2 = {x: obj.derivative(2) for x, obj in f.items()}
+
+    def _mask_pairs(self, i_p, j_p):
+        """Iterate over pair masks."""
+        numi_p, numj_p = self.atoms.numbers[i_p], self.atoms.numbers[j_p]
+
+        for pair in self.dict:
+            mask = (numi_p == pair[0]) & (numj_p == pair[1])
+
+            if pair[0] != pair[1]:
+                mask |= (numi_p == pair[1]) & (numj_p == pair[0])
+
+            yield mask, pair
+
 
     def calculate(self, atoms, properties, system_changes):
         MatscipyCalculator.calculate(self, atoms, properties, system_changes)
 
         nb_atoms = len(self.atoms)
-        atnums = self.atoms.numbers
-        atnums_in_system = set(atnums)
-
         i_p, j_p, r_p, r_pc = neighbour_list('ijdD', self.atoms, self.dict)
 
         e_p = np.zeros_like(r_p)
         de_p = np.zeros_like(r_p)
-        for params, pair in enumerate(self.dict):
-            if pair[0] == pair[1]:
-                mask1 = atnums[i_p] == pair[0]
-                mask2 = atnums[j_p] == pair[0]
-                mask = np.logical_and(mask1, mask2)
 
-                e_p[mask] = self.f[pair](r_p[mask])
-                de_p[mask] = self.df[pair](r_p[mask])
+        for mask, pair in self._mask_pairs(i_p, j_p):
+            e_p[mask] = self.f[pair](r_p[mask])
+            de_p[mask] = self.df[pair](r_p[mask])
 
-            if pair[0] != pair[1]:
-                mask1 = np.logical_and(
-                    atnums[i_p] == pair[0], atnums[j_p] == pair[1])
-                mask2 = np.logical_and(
-                    atnums[i_p] == pair[1], atnums[j_p] == pair[0])
-                mask = np.logical_or(mask1, mask2)
-
-                e_p[mask] = self.f[pair](r_p[mask])
-                de_p[mask] = self.df[pair](r_p[mask])
-
-        epot = 0.5*np.sum(e_p)
+        epot = 0.5 * np.sum(e_p)
 
         # Forces
-        df_pc = -0.5*de_p.reshape(-1, 1)*r_pc/r_p.reshape(-1, 1)
+        df_pc = -0.5 * de_p[_c] * r_pc / r_p[_c]
 
-        f_nc = mabincount(j_p, df_pc, nb_atoms) - mabincount(i_p, df_pc, nb_atoms)
+        f_nc = mabincount(j_p, df_pc, nb_atoms) \
+            - mabincount(i_p, df_pc, nb_atoms)
 
         # Virial
         virial_v = -np.array([r_pc[:, 0] * df_pc[:, 0],               # xx
@@ -322,7 +319,7 @@ class PairPotential(MatscipyCalculator):
             Output format of the hessian matrix.
 
         divide_by_masses: bool
-            if true return the dynamic matrix else hessian matrix 
+            if true return the dynamic matrix else hessian matrix
 
         Restrictions
         ----------
@@ -345,28 +342,13 @@ class PairPotential(MatscipyCalculator):
         e_p = np.zeros_like(r_p)
         de_p = np.zeros_like(r_p)
         dde_p = np.zeros_like(r_p)
-        for params, pair in enumerate(dict):
-            if pair[0] == pair[1]:
-                mask1 = atnums[i_p] == pair[0]
-                mask2 = atnums[j_p] == pair[0]
-                mask = np.logical_and(mask1, mask2)
 
-                e_p[mask] = f[pair](r_p[mask])
-                de_p[mask] = df[pair](r_p[mask])
-                dde_p[mask] = df2[pair](r_p[mask])
+        for mask, pair in self._mask_pairs(i_p, j_p):
+            e_p[mask] = f[pair](r_p[mask])
+            de_p[mask] = df[pair](r_p[mask])
+            dde_p[mask] = df2[pair](r_p[mask])
 
-            if pair[0] != pair[1]:
-                mask1 = np.logical_and(
-                    atnums[i_p] == pair[0], atnums[j_p] == pair[1])
-                mask2 = np.logical_and(
-                    atnums[i_p] == pair[1], atnums[j_p] == pair[0])
-                mask = np.logical_or(mask1, mask2)
-
-                e_p[mask] = f[pair](r_p[mask])
-                de_p[mask] = df[pair](r_p[mask])
-                dde_p[mask] = df2[pair](r_p[mask])
-        
-        n_pc = (r_pc.T/r_p).T
+        n_pc = r_pc / r_p[_c]
         H_pcc = -(dde_p * (n_pc.reshape(-1, 3, 1)
                            * n_pc.reshape(-1, 1, 3)).T).T
         H_pcc += -(de_p/r_p * (np.eye(3, dtype=n_pc.dtype)
@@ -381,7 +363,7 @@ class PairPotential(MatscipyCalculator):
             if divide_by_masses:
                 H = bsr_matrix(((H_pcc.T/geom_mean_mass_p).T, j_p, first_i), shape=(3*nb_atoms, 3*nb_atoms))
 
-            else: 
+            else:
                 H = bsr_matrix((H_pcc, j_p, first_i), shape=(3*nb_atoms, 3*nb_atoms))
 
             Hdiag_icc = np.empty((nb_atoms, 3, 3))

--- a/matscipy/calculators/pair_potential/calculator.py
+++ b/matscipy/calculators/pair_potential/calculator.py
@@ -272,9 +272,15 @@ _c, _cc = np.s_[..., np.newaxis], np.s_[..., np.newaxis, np.newaxis]
 
 
 class PairPotential(MatscipyCalculator):
-    implemented_properties = ['energy', 'free_energy',
-                              'stress', 'forces', 'hessian',
-                              'nonaffine_forces']
+    implemented_properties = [
+        'energy', 'free_energy', 'stress', 'forces',
+
+        'hessian', 'nonaffine_forces', 'birch_coefficients',
+        'nonaffine_elastic_contribution',
+        'stress_elastic_contribution',
+        'born_constants'
+    ]
+
     default_parameters = {}
     name = 'PairPotential'
 
@@ -345,16 +351,10 @@ class PairPotential(MatscipyCalculator):
                               r_pc[:, 0] * df_pc[:, 2],               # xz
                               r_pc[:, 0] * df_pc[:, 1]]).sum(axis=1)  # xy
 
-        self.results = {'energy': epot,
-                        'free_energy': epot,
-                        'stress': virial_v / atoms.get_volume(),
-                        'forces': f_nc}
-
-        if 'hessian' in properties:
-            self.results['hessian'] = self.get_hessian(atoms)
-
-        if 'nonaffine_forces' in properties:
-            self.results['nonaffine_forces'] = self.get_nonaffine_forces(atoms)
+        self.results.update({'energy': epot,
+                             'free_energy': epot,
+                             'stress': virial_v / atoms.get_volume(),
+                             'forces': f_nc})
 
     ###
 

--- a/matscipy/calculators/pair_potential/calculator.py
+++ b/matscipy/calculators/pair_potential/calculator.py
@@ -273,7 +273,8 @@ _c, _cc = np.s_[..., np.newaxis], np.s_[..., np.newaxis, np.newaxis]
 
 class PairPotential(MatscipyCalculator):
     implemented_properties = ['energy', 'free_energy',
-                              'stress', 'forces', 'hessian']
+                              'stress', 'forces', 'hessian',
+                              'nonaffine_forces']
     default_parameters = {}
     name = 'PairPotential'
 
@@ -318,7 +319,7 @@ class PairPotential(MatscipyCalculator):
         super().calculate(atoms, properties, system_changes)
 
         nb_atoms = len(self.atoms)
-        i_p, j_p, r_p, r_pc = neighbour_list('ijdD', self.atoms, self.dict)
+        i_p, j_p, r_p, r_pc = neighbour_list('ijdD', atoms, self.dict)
         qi_p, qj_p = self._get_charges(i_p, j_p)
 
         e_p = np.zeros_like(r_p)
@@ -346,8 +347,14 @@ class PairPotential(MatscipyCalculator):
 
         self.results = {'energy': epot,
                         'free_energy': epot,
-                        'stress': virial_v/self.atoms.get_volume(),
+                        'stress': virial_v / atoms.get_volume(),
                         'forces': f_nc}
+
+        if 'hessian' in properties:
+            self.results['hessian'] = self.get_hessian(atoms)
+
+        if 'nonaffine_forces' in properties:
+            self.results['nonaffine_forces'] = self.get_nonaffine_forces(atoms)
 
     ###
 

--- a/matscipy/elasticity.py
+++ b/matscipy/elasticity.py
@@ -29,6 +29,7 @@ import numpy as np
 import scipy.stats as scipy_stats
 from numpy.linalg import inv, norm
 from scipy.linalg import sqrtm
+from scipy.sparse.linalg import cg
 
 import ase.units as units
 from ase.atoms import Atoms
@@ -100,13 +101,13 @@ def Voigt_6x6_to_full_3x3x3x3(C):
     ----------
     C : array_like
         6x6 stiffness matrix (Voigt notation).
-    
+
     Returns
     -------
     C : array_like
         3x3x3x3 stiffness matrix.
     """
-    
+
     C = np.asarray(C)
     C_out = np.zeros((3,3,3,3), dtype=float)
     for i, j, k, l in itertools.product(range(3), range(3), range(3), range(3)):
@@ -247,7 +248,7 @@ def invariants(s, syy=None, szz=None, syz=None, sxz=None, sxy=None,
 
 def rotate_cubic_elastic_constants(C11, C12, C44, A, tol=1e-6):
     """
-    Return rotated elastic moduli for a cubic crystal given the elastic 
+    Return rotated elastic moduli for a cubic crystal given the elastic
     constant in standard C11, C12, C44 notation.
 
     Parameters
@@ -266,7 +267,7 @@ def rotate_cubic_elastic_constants(C11, C12, C44, A, tol=1e-6):
     A = np.asarray(A)
 
     # Is this a rotation matrix?
-    if np.sometrue(np.abs(np.dot(np.array(A), np.transpose(np.array(A))) - 
+    if np.sometrue(np.abs(np.dot(np.array(A), np.transpose(np.array(A))) -
                           np.eye(3, dtype=float)) > tol):
         raise RuntimeError('Matrix *A* does not describe a rotation.')
 
@@ -297,7 +298,7 @@ def rotate_cubic_elastic_constants(C11, C12, C44, A, tol=1e-6):
 
 def rotate_elastic_constants(C, A, tol=1e-6):
     """
-    Return rotated elastic moduli for a general crystal given the elastic 
+    Return rotated elastic moduli for a general crystal given the elastic
     constant in Voigt notation.
 
     Parameters
@@ -316,7 +317,7 @@ def rotate_elastic_constants(C, A, tol=1e-6):
     A = np.asarray(A)
 
     # Is this a rotation matrix?
-    if np.sometrue(np.abs(np.dot(np.array(A), np.transpose(np.array(A))) - 
+    if np.sometrue(np.abs(np.dot(np.array(A), np.transpose(np.array(A))) -
                           np.eye(3, dtype=float)) > tol):
         raise RuntimeError('Matrix *A* does not describe a rotation.')
 
@@ -357,7 +358,7 @@ class CubicElasticModuli:
         A = np.asarray(A)
 
         # Is this a rotation matrix?
-        if np.sometrue(np.abs(np.dot(np.array(A), np.transpose(np.array(A))) - 
+        if np.sometrue(np.abs(np.dot(np.array(A), np.transpose(np.array(A))) -
                               np.eye(3, dtype=float)) > self.tol):
             raise RuntimeError('Matrix *A* does not describe a rotation.')
 
@@ -388,7 +389,7 @@ class CubicElasticModuli:
         A = np.asarray(A)
 
         # Is this a rotation matrix?
-        if np.sometrue(np.abs(np.dot(np.array(A), np.transpose(np.array(A))) - 
+        if np.sometrue(np.abs(np.dot(np.array(A), np.transpose(np.array(A))) -
                               np.eye(3, dtype=float) ) > self.tol):
             raise RuntimeError('Matrix *A* does not describe a rotation.')
 
@@ -434,7 +435,7 @@ class CubicElasticModuli:
 
 ###
 
-def measure_triclinic_elastic_constants(a, delta=0.001, optimizer=None, 
+def measure_triclinic_elastic_constants(a, delta=0.001, optimizer=None,
                                         logfile=None, **kwargs):
     """
     Brute-force measurement of elastic constants for a triclinic (general)
@@ -469,7 +470,7 @@ def measure_triclinic_elastic_constants(a, delta=0.001, optimizer=None,
         for j in range(3):
             a.set_cell(cell, scale_atoms=True)
             a.set_positions(r0)
-        
+
             e = np.zeros((3, 3))
             e[i, j] += 0.5*delta
             e[j, i] += 0.5*delta
@@ -552,7 +553,7 @@ Cij_symmetry = {
                                 [ 0,  0,  0,  4,  0,  20],
                                 [10, 14, 17,  0,  5,  0],
                                 [ 0,  0,  0, 20,  0,  6]]),
-    
+
     'triclinic':       np.array([[ 1,  7,  8,  9,  10, 11],
                                  [ 7,  2, 12,  13, 14, 15],
                                  [ 8, 12,  3,  16, 17, 18],
@@ -740,7 +741,7 @@ def fit_elastic_constants(a, symmetry='triclinic', N_steps=5, delta=1e-2, optimi
     N_steps : int
         Number of atomic configurations to generate for each strain pattern.
         Default is 5. Absolute strain values range from -delta*N_steps/2
-        to +delta*N_steps/2.    
+        to +delta*N_steps/2.
     delta : float
         Strain increment for analytical derivatives of stresses.
         Default is 1e-2.
@@ -754,7 +755,7 @@ def fit_elastic_constants(a, symmetry='triclinic', N_steps=5, delta=1e-2, optimi
         and summarise results of C_ij and estimated errors. Default True.
     graphics : bool
         If True, use :mod:`matplotlib.pyplot` to plot the stress vs. strain
-        curve for each C_ij component fitted. Default True. 
+        curve for each C_ij component fitted. Default True.
     logfile : bool
         Log file to write optimizer output to. Default None (i.e. suppress
         output).
@@ -769,7 +770,7 @@ def fit_elastic_constants(a, symmetry='triclinic', N_steps=5, delta=1e-2, optimi
         If scipy.stats module is available then error estimates for each C_ij
         component are obtained from the accuracy of the linear regression.
         Otherwise an array of np.zeros((6,6)) is returned.
-    
+
     Notes
     -----
 
@@ -992,14 +993,14 @@ def youngs_modulus(C, l):
     Notes
     -----
 
-    Formula is from W. Brantley, Calculated elastic constants for stress problems associated 
+    Formula is from W. Brantley, Calculated elastic constants for stress problems associated
     with semiconductor devices. J. Appl. Phys., 44, 534 (1973).
-    """  
+    """
 
     S = inv(C)        # Compliance matrix
     lhat = l/norm(l)  # Normalise directions
 
-    # Youngs modulus in direction l, ratio of stress sigma_l 
+    # Youngs modulus in direction l, ratio of stress sigma_l
     # to strain response epsilon_l
     E = 1.0/(S[0,0] - 2.0*(S[0,0]-S[0,1]-0.5*S[3,3])*(lhat[0]*lhat[0]*lhat[1]*lhat[1] +
          lhat[1]*lhat[1]*lhat[2]*lhat[2] +
@@ -1016,21 +1017,21 @@ def poisson_ratio(C, l, m):
     Notes
     -----
 
-    Formula is from W. Brantley, Calculated elastic constants for stress problems associated 
+    Formula is from W. Brantley, Calculated elastic constants for stress problems associated
     with semiconductor devices. J. Appl. Phys., 44, 534 (1973).
     """
-    
+
     S = inv(C)        # Compliance matrix
     lhat = l/norm(l)  # Normalise directions
     mhat = m/norm(m)
 
-    # Poisson ratio v_lm: response in m direction to strain in 
+    # Poisson ratio v_lm: response in m direction to strain in
     # l direction, v_lm = - epsilon_m/epsilon_l
     v = -((S[0,1] + (S[0,0]-S[0,1]-0.5*S[3,3])*(lhat[0]*lhat[0]*mhat[0]*mhat[0] +
          lhat[1]*lhat[1]*mhat[1]*mhat[1] +
-         lhat[2]*lhat[2]*mhat[2]*mhat[2])) / 
-         (S[0,0] - 2.0*(S[0,0]-S[0,1]-0.5*S[3,3])*(lhat[0]*lhat[0]*lhat[1]*lhat[1] + 
-         lhat[1]*lhat[1]*lhat[2]*lhat[2] + 
+         lhat[2]*lhat[2]*mhat[2]*mhat[2])) /
+         (S[0,0] - 2.0*(S[0,0]-S[0,1]-0.5*S[3,3])*(lhat[0]*lhat[0]*lhat[1]*lhat[1] +
+         lhat[1]*lhat[1]*lhat[2]*lhat[2] +
          lhat[0]*lhat[0]*lhat[2]*lhat[2])))
     return v
 
@@ -1038,14 +1039,14 @@ def poisson_ratio(C, l, m):
 def elastic_moduli(C, l=np.array([1, 0, 0]), R=None, tol=1e-6):
     """
     Calculate elastic moduli from 6x6 elastic constant matrix C_{ij}.
-    
+
     The elastic moduli calculated are: Young's muduli, Poisson's ratios,
     shear moduli, bulk mudulus and bulk mudulus tensor.
-    
+
     If a direction l is specified, the system is rotated to have it as its
     x direction (see Notes for details). If R is specified the system is
     rotated according to it.
-    
+
     Parameters
     ----------
     C : array_like
@@ -1055,7 +1056,7 @@ def elastic_moduli(C, l=np.array([1, 0, 0]), R=None, tol=1e-6):
         of the original system)
     R : array_like, optional
         3x3 rotation matrix.
-    
+
     Returns
     -------
     E : array_like
@@ -1069,13 +1070,13 @@ def elastic_moduli(C, l=np.array([1, 0, 0]), R=None, tol=1e-6):
         Bulk modulus.
     K : array_like
         3x3 matrix with bulk modulus tensor.
-    
+
     Other Parameters
     ----------------
     tol : float, optional
         tolerance for checking validity of rotation and comparison
         of vectors.
-    
+
     Notes
     ---
     It works by rotating the elastic constant tensor to the desired
@@ -1083,18 +1084,18 @@ def elastic_moduli(C, l=np.array([1, 0, 0]), R=None, tol=1e-6):
     If only l is specified there is an infinite number of possible
     rotations. The chosen one is a rotation along the axis orthogonal
     to the plane defined by the vectors (1, 0, 0) and l.
-    
+
     Bulk modulus tensor as defined in
     O. Rand and V. Rovenski, "Analytical Methods in Anisotropic
     Elasticity", Birkh\"auser (2005), pp. 71.
-    
+
     """
-    
+
     if R is not None:
         R = np.asarray(R)
 
         # Is this a rotation matrix?
-        if np.sometrue(np.abs(np.dot(np.array(R), np.transpose(np.array(R))) - 
+        if np.sometrue(np.abs(np.dot(np.array(R), np.transpose(np.array(R))) -
                               np.eye(3, dtype=float)) > tol):
             raise RuntimeError('Matrix *R* does not describe a rotation.')
     else:
@@ -1141,9 +1142,126 @@ def elastic_moduli(C, l=np.array([1, 0, 0]), R=None, tol=1e-6):
 
     # Bulk modulus
     B = 1/np.sum(S[0:3, 0:3])
-    
+
     # Bulk modulus tensor
     Crt = Voigt_6x6_to_full_3x3x3x3(Cr)
     K = np.einsum('ijkk', Crt)
 
     return E, nu, Gm, B, K
+
+def get_non_affine_contribution_to_elastic_constants(atoms,
+                                                     eigenvalues=None,
+                                                     eigenvectors=None,
+                                                     pc_parameters=None,
+                                                     cg_parameters={
+                                                         "x0": None,
+                                                         "tol": 1e-5,
+                                                         "maxiter": None,
+                                                         "M": None,
+                                                         "callback": None,
+                                                         "atol": 1e-5}):
+    """
+    Compute the correction of non-affine displacements to the elasticity tensor.
+    The computation of the occuring inverse of the Hessian matrix is bypassed by using a cg solver.
+
+    If eigenvalues and and eigenvectors are given the inverse of the Hessian can be easily computed.
+
+    Parameters
+    ----------
+    atoms: ase.Atoms
+        Atomic configuration in a local or global minima.
+
+    eigenvalues: array
+        Eigenvalues in ascending order obtained by diagonalization of Hessian matrix.
+        If given, use eigenvalues and eigenvectors to compute non-affine contribution.
+
+    eigenvectors: array
+        Eigenvectors corresponding to eigenvalues.
+
+    cg_parameters: dict
+        Dictonary for the conjugate-gradient solver.
+
+        x0: {array, matrix}
+            Starting guess for the solution.
+
+        tol/atol: float, optional
+            Tolerances for convergence, norm(residual) <= max(tol*norm(b), atol).
+
+        maxiter: int
+            Maximum number of iterations. Iteration will stop after maxiter steps even if the specified tolerance has not been achieved.
+
+        M: {sparse matrix, dense matrix, LinearOperator}
+            Preconditioner for A.
+
+        callback: function
+            User-supplied function to call after each iteration.
+
+    pc_parameters: dict
+        Dictonary for the incomplete LU decomposition of the Hessian.
+
+        A: array_like
+            Sparse matrix to factorize.
+
+        drop_tol: float
+            Drop tolerance for an incomplete LU decomposition.
+
+        fill_factor: float
+            Specifies the fill ratio upper bound.
+
+        drop_rule: str
+            Comma-separated string of drop rules to use.
+
+        permc_spec: str
+            How to permute the columns of the matrix for sparsity.
+
+        diag_pivot_thresh: float
+            Threshold used for a diagonal entry to be an acceptable pivot.
+
+        relax: int
+            Expert option for customizing the degree of relaxing supernodes.
+
+        panel_size: int
+            Expert option for customizing the panel size.
+
+        options: dict
+            Dictionary containing additional expert options to SuperLU.
+    """
+
+    nat = len(atoms)
+
+    if (eigenvalues is not None) and (eigenvectors is not None):
+        naforces_icab = atoms.calc.get_property('nonaffine_forces')
+
+        G_incc = (eigenvectors.T).reshape(-1, 3*nat, 1, 1) * naforces_icab.reshape(1, 3*nat, 3, 3)
+        G_incc = (G_incc.T/np.sqrt(eigenvalues)).T
+        G_icc  = np.sum(G_incc, axis=1)
+        C_abab = np.sum(G_icc.reshape(-1,3,3,1,1) * G_icc.reshape(-1,1,1,3,3), axis=0)
+
+    else:
+        H_nn = atoms.calc.get_property('hessian')
+        naforces_icab = atoms.calc.get_property('nonaffine_forces')
+
+        if pc_parameters != None:
+            # Transform H to csc
+            H_nn = H_nn.tocsc()
+
+            # Compute incomplete LU
+            approx_Hinv = spilu(H_nn, **pc_parameters)
+            operator_Hinv = LinearOperator(H_nn.shape, approx_Hinv.solve)
+            cg_parameters["M"] = operator_Hinv
+
+        D_iab = np.zeros((3*nat, 3, 3))
+        for i in range(3):
+            for j in range(3):
+                x, info = cg(H_nn, naforces_icab[:, :, i, j].flatten(), **cg_parameters)
+                if info != 0:
+                    print("info: ", info)
+                    raise RuntimeError(" info > 0: CG tolerance not achieved, info < 0: Exceeded number of iterations.")
+                D_iab[:,i,j] = x
+
+        C_abab = np.sum(naforces_icab.reshape(3*nat, 3, 3, 1, 1) * D_iab.reshape(3*nat, 1, 1, 3, 3), axis=0)
+
+    # Symmetrize
+    C_abab = (C_abab + C_abab.swapaxes(0, 1) + C_abab.swapaxes(2, 3) + C_abab.swapaxes(0, 1).swapaxes(2, 3)) / 4
+
+    return -C_abab/atoms.get_volume()

--- a/matscipy/neighbours.py
+++ b/matscipy/neighbours.py
@@ -22,6 +22,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from collections import defaultdict
 import numpy as np
 
 from ase.data import atomic_numbers
@@ -226,7 +227,10 @@ e_nc = (dr_nc.T/abs_dr_n).T
                              'separate atomic numbers at the same time.')
         numbers = atoms.numbers.astype(np.int32)
 
-    if isinstance(cutoff, dict):
+    if isinstance(cutoff, defaultdict):
+        _cutoff = cutoff.default_factory()
+
+    elif isinstance(cutoff, dict):
         maxel = np.max(numbers)
         _cutoff = np.zeros([maxel+1, maxel+1], dtype=float)
         for (el1, el2), c in cutoff.items():

--- a/tests/test_ewald.py
+++ b/tests/test_ewald.py
@@ -283,8 +283,11 @@ def test_birch_coefficients_alpha_quartz():
 
     FIRE(atoms, logfile=None).run(fmax=1e-2)
 
+    C_ana = full_3x3x3x3_to_Voigt_6x6(
+        atoms.calc.get_property('birch_coefficients'), check_symmetry=False)
+
     C_num, Cerr = fit_elastic_constants(atoms, symmetry="triclinic", N_steps=11, delta=1e-5, optimizer=None, verbose=False)
-    C_ana = full_3x3x3x3_to_Voigt_6x6(b.get_birch_coefficients(atoms), check_symmetry=False)
+
 
     print("Stress: \n", atoms.get_stress() / GPa)
     print("C_num: \n", C_num / GPa)
@@ -312,8 +315,10 @@ def test_full_elastic_alpha_quartz():
     FIRE(ase.constraints.UnitCellFilter(atoms, mask=[1, 1, 1, 0, 0, 0]), logfile=None).run(fmax=1e-3)
 
     C_num, Cerr = fit_elastic_constants(atoms, symmetry="triclinic", N_steps=11, delta=1e-3, optimizer=FIRE, fmax=1e-3, logfile=None, verbose=False)
-    C_ana = full_3x3x3x3_to_Voigt_6x6(b.get_birch_coefficients(atoms), check_symmetry=False)
-    C_na = full_3x3x3x3_to_Voigt_6x6(b.get_non_affine_contribution_to_elastic_constants(atoms))
+    C_ana = full_3x3x3x3_to_Voigt_6x6(
+        atoms.calc.get_property('birch_coefficients'), check_symmetry=False)
+    C_na = full_3x3x3x3_to_Voigt_6x6(
+        atoms.calc.get_property('nonaffine_elastic_contribution'))
 
     print("stress: \n", atoms.get_stress())
     print("C_num: \n", C_num )
@@ -489,7 +494,8 @@ def test_birch_coefficients_beta_cristobalite():
     FIRE(atoms, logfile=None).run(fmax=1e-2)
 
     C_num, Cerr = fit_elastic_constants(atoms, symmetry="triclinic", N_steps=11, delta=1e-5, optimizer=None, verbose=False)
-    C_ana = full_3x3x3x3_to_Voigt_6x6(b.get_birch_coefficients(atoms), check_symmetry=False)
+    C_ana = full_3x3x3x3_to_Voigt_6x6(
+        atoms.calc.get_property('birch_coefficients'), check_symmetry=False)
 
     print("C_num: \n", C_num)
     print("C_ana: \n", C_ana)
@@ -517,8 +523,10 @@ def test_non_affine_elastic_beta_cristobalite():
     FIRE(ase.constraints.UnitCellFilter(atoms, mask=[1, 1, 1, 0, 0, 0]), logfile=None).run(fmax=1e-3)
 
     C_num, Cerr = fit_elastic_constants(atoms, symmetry="triclinic", N_steps=11, delta=1e-3, optimizer=FIRE, fmax=1e-3, logfile=None, verbose=False)
-    C_ana = full_3x3x3x3_to_Voigt_6x6(b.get_birch_coefficients(atoms), check_symmetry=False)
-    C_na = full_3x3x3x3_to_Voigt_6x6(b.get_non_affine_contribution_to_elastic_constants(atoms))
+    C_ana = full_3x3x3x3_to_Voigt_6x6(
+        atoms.calc.get_property('birch_coefficients'), check_symmetry=False)
+    C_na = full_3x3x3x3_to_Voigt_6x6(
+        atoms.calc.get_property('nonaffine_elastic_contribution'))
 
     print("stress: \n", atoms.get_stress())
     print("C_num: \n", C_num)

--- a/tests/test_ewald.py
+++ b/tests/test_ewald.py
@@ -64,9 +64,15 @@ from ase.calculators.test import numeric_stress
 
 from matscipy.calculators.ewald import Ewald
 from matscipy.calculators.pair_potential.calculator import PairPotential, BeestKramerSanten
-from matscipy.elasticity import fit_elastic_constants, elastic_moduli, full_3x3x3x3_to_Voigt_6x6, measure_triclinic_elastic_constants
 from matscipy.hessian_finite_differences import fd_hessian
 from matscipy.numpy_tricks import mabincount
+from matscipy.elasticity import (
+    fit_elastic_constants,
+    elastic_moduli,
+    full_3x3x3x3_to_Voigt_6x6,
+    measure_triclinic_elastic_constants,
+    get_non_affine_contribution_to_elastic_constants
+)
 
 ###
 
@@ -318,7 +324,7 @@ def test_full_elastic_alpha_quartz():
     C_ana = full_3x3x3x3_to_Voigt_6x6(
         atoms.calc.get_property('birch_coefficients'), check_symmetry=False)
     C_na = full_3x3x3x3_to_Voigt_6x6(
-        atoms.calc.get_property('nonaffine_elastic_contribution'))
+        get_non_affine_contribution_to_elastic_constants(atoms))
 
     print("stress: \n", atoms.get_stress())
     print("C_num: \n", C_num )
@@ -526,7 +532,7 @@ def test_non_affine_elastic_beta_cristobalite():
     C_ana = full_3x3x3x3_to_Voigt_6x6(
         atoms.calc.get_property('birch_coefficients'), check_symmetry=False)
     C_na = full_3x3x3x3_to_Voigt_6x6(
-        atoms.calc.get_property('nonaffine_elastic_contribution'))
+        get_non_affine_contribution_to_elastic_constants(atoms))
 
     print("stress: \n", atoms.get_stress())
     print("C_num: \n", C_num)

--- a/tests/test_ewald.py
+++ b/tests/test_ewald.py
@@ -43,8 +43,6 @@
 import pytest
 import numpy as np
 
-import ase
-import ase.constraints
 from ase.optimize import FIRE
 from ase.units import GPa
 from ase.lattice.hexagonal import HexagonalFactory
@@ -53,74 +51,91 @@ from ase.calculators.mixing import SumCalculator
 
 from matscipy.calculators.ewald import Ewald
 from matscipy.calculators.pair_potential.calculator import (
-    PairPotential, BeestKramerSanten
+    PairPotential,
+    BeestKramerSanten,
 )
-from matscipy.hessian_finite_differences import fd_hessian
+from matscipy.hessian_finite_differences import (
+    fd_hessian,
+    get_numerical_non_affine_forces,
+)
 from matscipy.elasticity import (
     fit_elastic_constants,
     full_3x3x3x3_to_Voigt_6x6,
-    get_non_affine_contribution_to_elastic_constants
+    get_non_affine_contribution_to_elastic_constants,
 )
 
 
 ###
 
+
 class alpha_quartz(HexagonalFactory):
     """
     Factory to create an alpha quartz crystal structure
     """
+
     xtal_name = "alpha_quartz"
-    bravais_basis = [[0, 0.4763, 0.6667], [0.4763, 0, 0.3333], [0.5237, 0.5237, 0],
-        [0.1588, 0.7439, 0.4612], [0.2561, 0.4149, 0.7945], [0.4149, 0.2561, 0.2055],
-        [0.5851, 0.8412, 0.1279], [0.7439, 0.1588, 0.5388], [0.8412, 0.5851, 0.8721]]
-    element_basis = (0, 0, 0, 1, 1, 1, 1 ,1, 1)
+    bravais_basis = [
+        [0, 0.4763, 0.6667],
+        [0.4763, 0, 0.3333],
+        [0.5237, 0.5237, 0],
+        [0.1588, 0.7439, 0.4612],
+        [0.2561, 0.4149, 0.7945],
+        [0.4149, 0.2561, 0.2055],
+        [0.5851, 0.8412, 0.1279],
+        [0.7439, 0.1588, 0.5388],
+        [0.8412, 0.5851, 0.8721],
+    ]
+    element_basis = (0, 0, 0, 1, 1, 1, 1, 1, 1)
 
 
 class beta_cristobalite(SimpleCubicFactory):
     """
     Factory to create a beta cristobalite crystal structure
     """
+
     xtal_name = "beta_cristobalite"
-    bravais_basis = [[0.98184000, 0.51816000,0.48184000],
-                    [0.51816000, 0.48184000, 0.98184000],
-                    [0.48184000, 0.98184000, 0.51816000],
-                    [0.01816000, 0.01816000, 0.01816000],
-                    [0.72415800, 0.77584200, 0.22415800],
-                    [0.77584200, 0.22415800, 0.72415800],
-                    [0.22415800, 0.72415800, 0.77584200],
-                    [0.27584200, 0.27584200, 0.27584200],
-                    [0.86042900, 0.34389100, 0.55435200],
-                    [0.36042900, 0.15610900, 0.44564800],
-                    [0.13957100, 0.84389100, 0.94564800],
-                    [0.15610900, 0.44564800, 0.36042900],
-                    [0.94564800, 0.13957100, 0.84389100],
-                    [0.44564800, 0.36042900, 0.15610900],
-                    [0.34389100, 0.55435200, 0.86042900],
-                    [0.55435200, 0.86042900, 0.34389100],
-                    [0.14694300, 0.14694300, 0.14694300],
-                    [0.35305700, 0.85305700, 0.64694300],
-                    [0.64694300, 0.35305700, 0.85305700],
-                    [0.85305700, 0.64694300, 0.35305700],
-                    [0.63957100, 0.65610900, 0.05435200],
-                    [0.05435200, 0.63957100, 0.65610900],
-                    [0.65610900, 0.05435200, 0.63957100],
-                    [0.84389100, 0.94564800, 0.13957100]]
-    element_basis = tuple([0]*8 + [1]*16)
+    bravais_basis = [
+        [0.98184000, 0.51816000, 0.48184000],
+        [0.51816000, 0.48184000, 0.98184000],
+        [0.48184000, 0.98184000, 0.51816000],
+        [0.01816000, 0.01816000, 0.01816000],
+        [0.72415800, 0.77584200, 0.22415800],
+        [0.77584200, 0.22415800, 0.72415800],
+        [0.22415800, 0.72415800, 0.77584200],
+        [0.27584200, 0.27584200, 0.27584200],
+        [0.86042900, 0.34389100, 0.55435200],
+        [0.36042900, 0.15610900, 0.44564800],
+        [0.13957100, 0.84389100, 0.94564800],
+        [0.15610900, 0.44564800, 0.36042900],
+        [0.94564800, 0.13957100, 0.84389100],
+        [0.44564800, 0.36042900, 0.15610900],
+        [0.34389100, 0.55435200, 0.86042900],
+        [0.55435200, 0.86042900, 0.34389100],
+        [0.14694300, 0.14694300, 0.14694300],
+        [0.35305700, 0.85305700, 0.64694300],
+        [0.64694300, 0.35305700, 0.85305700],
+        [0.85305700, 0.64694300, 0.35305700],
+        [0.63957100, 0.65610900, 0.05435200],
+        [0.05435200, 0.63957100, 0.65610900],
+        [0.65610900, 0.05435200, 0.63957100],
+        [0.84389100, 0.94564800, 0.13957100],
+    ]
+    element_basis = tuple([0] * 8 + [1] * 16)
 
 
 calc_alpha_quartz = {
     (14, 14): BeestKramerSanten(0, 1, 0, 2.9),
     (14, 8): BeestKramerSanten(18003.7572, 4.87318, 133.5381, 2.9),
-    (8, 8): BeestKramerSanten(1388.7730, 2.76000, 175.0000, 2.9)
+    (8, 8): BeestKramerSanten(1388.7730, 2.76000, 175.0000, 2.9),
 }
 
 ewald_alpha_params = dict(
     accuracy=1e-6,
     cutoff=2.9,
     kspace={
-        'alpha': 1.28,
-        'nbk_c': np.array([8, 11, 9]),
-        'cutoff': 10.43,
+        "alpha": 1.28,
+        "nbk_c": np.array([8, 11, 9]),
+        "cutoff": 10.43,
     },
 )
 
@@ -132,32 +147,23 @@ ewald_beta_params = dict(
     accuracy=1e-6,
     cutoff=3.8,
     kspace={
-        'alpha': 0.96,
-        'nbk_c': np.array([9, 9, 9]),
-        'cutoff': 7,
+        "alpha": 0.96,
+        "nbk_c": np.array([9, 9, 9]),
+        "cutoff": 7,
     },
 )
 
-    # calc_alpha_quartz = {(14, 14): BKSEwald(0, 1, 0, 1.28, 2.9, 10.43, np.array([8, 11, 9]), 1e-6),
-    #                      (14, 8): BKSEwald(18003.7572, 4.87318, 133.5381, 1.28, 2.9, 10.43, np.array([8, 11, 9]), 1e-6),
-    #                      (8, 8): BKSEwald(1388.7730, 2.76000, 175.0000, 1.28, 2.9, 10.43, np.array([8, 11, 9]), 1e-6)}
 
-    # calc_beta_cristobalite = {(14, 14): BKSEwald(0, 1, 0, 0.96, 3.8, 7, np.array([9, 9, 9]), 1e-6),
-    #                           (14, 8): BKSEwald(18003.7572, 4.87318, 133.5381, 0.96, 3.8, 7, np.array([9, 9, 9]), 1e-6),
-    #                           (8, 8): BKSEwald(1388.7730, 2.76000, 175.0000, 0.96, 3.8, 7, np.array([9, 9, 9]), 1e-6)}
-
-###
-
-
-# Test for alpha quartz
-@pytest.mark.parametrize('a0', [4.7, 4.9, 5.1])
-def test_stress_alpha_quartz(a0):
-    """
-    Test the computation of stress
-    """
+@pytest.fixture(scope="module", params=[4.7, 4.9, 5.1])
+def alpha_quartz_ewald(request):
     structure = alpha_quartz()
-    atoms = structure(["Si", "O"], size=[1, 1, 1],
-                      latticeconstant={"a": a0, "b": a0, "c": 5.4})
+    a0 = request.param
+    atoms = structure(
+        ["Si", "O"],
+        size=[1, 1, 1],
+        latticeconstant={"a": a0, "b": a0, "c": 5.4},
+    )
+
     charges = np.zeros(len(atoms))
     charges[atoms.symbols == "Si"] = +2.4
     charges[atoms.symbols == "O"] = -1.2
@@ -166,9 +172,63 @@ def test_stress_alpha_quartz(a0):
     b = Ewald()
     b.set(**ewald_alpha_params)
     atoms.calc = b
+    return atoms
 
+
+@pytest.fixture(scope="module")
+def alpha_quartz_bks(alpha_quartz_ewald):
+    atoms = alpha_quartz_ewald
+    atoms.calc = SumCalculator([atoms.calc, PairPotential(calc_alpha_quartz)])
+
+    FIRE(atoms, logfile=None).run(fmax=1e-3)
+    return atoms
+
+
+@pytest.fixture(scope="module")
+def beta_cristobalite_ewald(request):
+    a0 = request.param
+    structure = beta_cristobalite()
+    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant=a0)
+    charges = np.zeros(len(atoms))
+    charges[atoms.symbols == "Si"] = +2.4
+    charges[atoms.symbols == "O"] = -1.2
+    atoms.set_array("charge", charges, dtype=float)
+
+    b = Ewald()
+    b.set(**ewald_beta_params)
+    atoms.calc = b
+    return atoms
+
+
+@pytest.fixture(scope="module")
+def beta_cristobalite_bks(request):
+    a0 = request.param
+    structure = beta_cristobalite()
+    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant=a0)
+    charges = np.zeros(len(atoms))
+    charges[atoms.symbols == "Si"] = +2.4
+    charges[atoms.symbols == "O"] = -1.2
+    atoms.set_array("charge", charges, dtype=float)
+
+    b = Ewald()
+    b.set(**ewald_beta_params)
+    atoms.calc = b
+    atoms.calc = SumCalculator(
+        [atoms.calc, PairPotential(calc_beta_cristobalite)]
+    )
+
+    FIRE(atoms, logfile=None).run(fmax=1e-3)
+    return atoms
+
+
+# Test for alpha quartz
+def test_stress_alpha_quartz(alpha_quartz_ewald):
+    """
+    Test the computation of stress
+    """
+    atoms = alpha_quartz_ewald
     s = atoms.get_stress()
-    sn = b.calculate_numerical_stress(atoms, d=0.001)
+    sn = atoms.calc.calculate_numerical_stress(atoms, d=0.001)
 
     print("Stress ana: \n", s)
     print("Stress num: \n", sn)
@@ -176,57 +236,27 @@ def test_stress_alpha_quartz(a0):
     np.testing.assert_allclose(s, sn, atol=1e-3)
 
 
-@pytest.mark.parametrize('a0', [4.7, 4.9, 5.1])
-def test_forces_alpha_quartz(a0):
+def test_forces_alpha_quartz(alpha_quartz_ewald):
     """
     Test the computation of forces
     """
-    structure = alpha_quartz()
-    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant={"a": a0, "b": a0, "c": 5.4, "gamma": 120})
-    print("len(a)", len(atoms))
-    charges = np.zeros(len(atoms))
-    for i in range(len(atoms)):
-        if atoms.get_chemical_symbols()[i] == "Si":
-            charges[i] = +2.4
-        elif atoms.get_chemical_symbols()[i] == "O":
-            charges[i] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
-
-    b = Ewald()
-    b.set(**ewald_alpha_params)
-    atoms.calc = b
-
+    atoms = alpha_quartz_ewald
     f = atoms.get_forces()
-    fn = b.calculate_numerical_forces(atoms, d=0.0001)
+    fn = atoms.calc.calculate_numerical_forces(atoms, d=0.0001)
 
-    print("f_ana: \n", f[:5,:])
-    print("f_num: \n", fn[:5,:])
+    print("f_ana: \n", f[:5, :])
+    print("f_num: \n", fn[:5, :])
 
     np.testing.assert_allclose(f, fn, atol=1e-3)
 
 
-def test_hessian_alpha_quartz():
+def test_hessian_alpha_quartz(alpha_quartz_bks):
     """
     Test the computation of the Hessian matrix
     """
-    structure = alpha_quartz()
-    atoms = structure(["Si", "O"], size=[1, 1, 1],
-                      latticeconstant={"a": 4.9, "b": 4.9, "c": 5.4, "gamma": 120})
-    charges = np.zeros(len(atoms))
-    for i in range(len(atoms)):
-        if atoms.get_chemical_symbols()[i] == "Si":
-            charges[i] = +2.4
-        elif atoms.get_chemical_symbols()[i] == "O":
-            charges[i] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
-
-    b = Ewald()
-    b.set(**ewald_alpha_params)
-    atoms.calc = SumCalculator([b, PairPotential(calc_alpha_quartz)])
-    FIRE(atoms, logfile=None).run(fmax=1e-2)
-
+    atoms = alpha_quartz_bks
     H_num = fd_hessian(atoms, dx=1e-5, indices=None)
-    H_ana = atoms.calc.get_property('hessian', atoms)
+    H_ana = atoms.calc.get_property("hessian", atoms)
 
     print("H_num: \n", H_num.todense()[:6, :6])
     print("H_ana: \n", H_ana[:6, :6])
@@ -234,28 +264,14 @@ def test_hessian_alpha_quartz():
     np.testing.assert_allclose(H_num.todense(), H_ana, atol=1e-3)
 
 
-def test_non_affine_forces_alpha_quartz():
+def test_non_affine_forces_alpha_quartz(alpha_quartz_bks):
     """
     Test the computation of non-affine forces
     """
-    structure = alpha_quartz()
-    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant={"a": 4.9, "b": 4.9, "c": 5.4, "gamma": 120})
-    charges = np.zeros(len(atoms))
-    for i in range(len(atoms)):
-        if atoms.get_chemical_symbols()[i] == "Si":
-            charges[i] = +2.4
-        elif atoms.get_chemical_symbols()[i] == "O":
-            charges[i] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
+    atoms = alpha_quartz_bks
 
-    b = Ewald()
-    b.set(**ewald_alpha_params)
-    atoms.calc = SumCalculator([b, PairPotential(calc_alpha_quartz)])
-
-    FIRE(atoms, logfile=None).run(fmax=1e-2)
-
-    naForces_ana = atoms.calc.get_property('nonaffine_forces')
-    naForces_num = b.get_numerical_non_affine_forces(atoms, d=1e-5)
+    naForces_ana = atoms.calc.get_property("nonaffine_forces")
+    naForces_num = get_numerical_non_affine_forces(atoms, d=1e-5)
 
     print("Num: \n", naForces_num[:1])
     print("Ana: \n", naForces_ana[:1])
@@ -263,30 +279,23 @@ def test_non_affine_forces_alpha_quartz():
     np.testing.assert_allclose(naForces_num, naForces_ana, atol=1e-2)
 
 
-def test_birch_coefficients_alpha_quartz():
+def test_birch_coefficients_alpha_quartz(alpha_quartz_bks):
     """
     Test the computation of the affine elastic constants + stresses
     """
-    structure = alpha_quartz()
-    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant={"a": 4.9, "b": 4.9, "c": 5.4, "gamma": 120})
-    charges = np.zeros(len(atoms))
-    for i in range(len(atoms)):
-        if atoms.get_chemical_symbols()[i] == "Si":
-            charges[i] = +2.4
-        elif atoms.get_chemical_symbols()[i] == "O":
-            charges[i] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
-
-    b = Ewald()
-    b.set(**ewald_alpha_params)
-    atoms.calc = SumCalculator([b, PairPotential(calc_alpha_quartz)])
-
-    FIRE(atoms, logfile=None).run(fmax=1e-2)
-
+    atoms = alpha_quartz_bks
     C_ana = full_3x3x3x3_to_Voigt_6x6(
-        atoms.calc.get_property('birch_coefficients'), check_symmetry=False)
+        atoms.calc.get_property("birch_coefficients"), check_symmetry=False
+    )
 
-    C_num, Cerr = fit_elastic_constants(atoms, symmetry="triclinic", N_steps=11, delta=1e-5, optimizer=None, verbose=False)
+    C_num, Cerr = fit_elastic_constants(
+        atoms,
+        symmetry="triclinic",
+        N_steps=11,
+        delta=1e-5,
+        optimizer=None,
+        verbose=False,
+    )
 
     print("Stress: \n", atoms.get_stress() / GPa)
     print("C_num: \n", C_num / GPa)
@@ -295,62 +304,50 @@ def test_birch_coefficients_alpha_quartz():
     np.testing.assert_allclose(C_num, C_ana, atol=1e-1)
 
 
-def test_full_elastic_alpha_quartz():
+def test_full_elastic_alpha_quartz(alpha_quartz_bks):
     """
-    Test the computation of the affine elastic constants + stresses + non-affine elastic constants
+    Test the computation of the affine elastic constants + stresses
+    + non-affine elastic constants
     """
-    structure = alpha_quartz()
-    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant={"a": 4.94, "b": 4.94, "c": 5.44, "gamma": 120})
-    charges = np.zeros(len(atoms))
-    charges[atoms.symbols == "Si"] = +2.4
-    charges[atoms.symbols == "O"] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
-
-    b = Ewald()
-    params = ewald_alpha_params.copy()
-    params["kspace"] = {}
-    b.set(**params)
-    atoms.calc = SumCalculator([b, PairPotential(calc_alpha_quartz)])
-    FIRE(ase.constraints.UnitCellFilter(atoms, mask=[1, 1, 1, 0, 0, 0]), logfile=None).run(fmax=1e-6)
-
-    C_num, Cerr = fit_elastic_constants(atoms, symmetry="triclinic", N_steps=11, delta=1e-4, optimizer=FIRE, fmax=1e-4, logfile=None, verbose=False)
+    atoms = alpha_quartz_bks
+    C_num, Cerr = fit_elastic_constants(
+        atoms,
+        symmetry="triclinic",
+        N_steps=11,
+        delta=1e-4,
+        optimizer=FIRE,
+        fmax=1e-4,
+        logfile=None,
+        verbose=False,
+    )
     C_ana = full_3x3x3x3_to_Voigt_6x6(
-        atoms.calc.get_property('birch_coefficients'), check_symmetry=False)
+        atoms.calc.get_property("birch_coefficients"), check_symmetry=False
+    )
     C_na = full_3x3x3x3_to_Voigt_6x6(
-        get_non_affine_contribution_to_elastic_constants(atoms))
+        get_non_affine_contribution_to_elastic_constants(atoms)
+    )
 
     print("stress: \n", atoms.get_stress())
     print("C_num: \n", C_num)
     print("C_ana: \n", C_ana + C_na)
 
-    np.testing.assert_allclose(C_num, C_ana+C_na, atol=1e-1)
+    np.testing.assert_allclose(C_num, C_ana + C_na, atol=1e-1)
 
 
 ###
 
-# Beta crisotbalite
 
-@pytest.mark.parametrize('a0', [6, 7, 8, 9])
-def test_stress_beta_cristobalite(a0):
+# Beta crisotbalite
+@pytest.mark.parametrize(
+    "beta_cristobalite_ewald", [6, 7, 8, 9], indirect=True
+)
+def test_stress_beta_cristobalite(beta_cristobalite_ewald):
     """
     Test the computation of stress
     """
-    structure = beta_cristobalite()
-    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant=a0)
-    charges = np.zeros(len(atoms))
-    for i in range(len(atoms)):
-        if atoms.get_chemical_symbols()[i] == "Si":
-            charges[i] = +2.4
-        elif atoms.get_chemical_symbols()[i] == "O":
-            charges[i] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
-
-    b = Ewald()
-    b.set(**ewald_beta_params)
-    atoms.calc = b
-
+    atoms = beta_cristobalite_ewald
     s = atoms.get_stress()
-    sn = b.calculate_numerical_stress(atoms, d=0.0001)
+    sn = atoms.calc.calculate_numerical_stress(atoms, d=0.0001)
 
     print("Stress ana: \n", s)
     print("Stress num: \n", sn)
@@ -358,82 +355,43 @@ def test_stress_beta_cristobalite(a0):
     np.testing.assert_allclose(s, sn, atol=1e-3)
 
 
-@pytest.mark.parametrize('a0', [7, 9])
-def test_forces_beta_cristobalite(a0):
+@pytest.mark.parametrize(
+    "beta_cristobalite_ewald", [6, 7, 8, 9], indirect=True
+)
+def test_forces_beta_cristobalite(beta_cristobalite_ewald):
     """
     Test the computation of forces
     """
-    structure = beta_cristobalite()
-    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant=a0)
-    charges = np.zeros(len(atoms))
-    for i in range(len(atoms)):
-        if atoms.get_chemical_symbols()[i] == "Si":
-            charges[i] = +2.4
-        elif atoms.get_chemical_symbols()[i] == "O":
-            charges[i] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
-
-    b = Ewald()
-    b.set(**ewald_beta_params)
-    atoms.calc = b
-
+    atoms = beta_cristobalite_ewald
     f = atoms.get_forces()
-    fn = b.calculate_numerical_forces(atoms, d=1e-5)
+    fn = atoms.calc.calculate_numerical_forces(atoms, d=1e-5)
 
-    print("forces ana: \n", f[:5,:])
-    print("forces num: \n", fn[:5,:])
+    print("forces ana: \n", f[:5, :])
+    print("forces num: \n", fn[:5, :])
 
     np.testing.assert_allclose(f, fn, atol=1e-3)
 
 
-def test_hessian_beta_cristobalite():
+@pytest.mark.parametrize("beta_cristobalite_bks", [6, 7, 8, 9], indirect=True)
+def test_hessian_beta_cristobalite(beta_cristobalite_bks):
     """
     Test the computation of the Hessian matrix
     """
-    structure = beta_cristobalite()
-    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant=7)
-    charges = np.zeros(len(atoms))
-    for i in range(len(atoms)):
-        if atoms.get_chemical_symbols()[i] == "Si":
-            charges[i] = +2.4
-        elif atoms.get_chemical_symbols()[i] == "O":
-            charges[i] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
-
-    b = Ewald()
-    b.set(**ewald_beta_params)
-    atoms.calc = SumCalculator([b, PairPotential(calc_beta_cristobalite)])
-
-    FIRE(atoms, logfile=None).run(fmax=1e-2)
-
+    atoms = beta_cristobalite_bks
     H_num = fd_hessian(atoms, dx=1e-5, indices=None)
-    H_ana = atoms.calc.get_property('hessian')
+    H_ana = atoms.calc.get_property("hessian")
 
     np.testing.assert_allclose(H_num.todense(), H_ana, atol=1e-3)
 
 
-def test_non_affine_forces_beta_cristobalite():
+@pytest.mark.parametrize("beta_cristobalite_bks", [6], indirect=True)
+def test_non_affine_forces_beta_cristobalite(beta_cristobalite_bks):
     """
     Test the computation of non-affine forces
     """
-    structure = beta_cristobalite()
-    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant=7)
-    charges = np.zeros(len(atoms))
-    for i in range(len(atoms)):
-        if atoms.get_chemical_symbols()[i] == "Si":
-            charges[i] = +2.4
-        elif atoms.get_chemical_symbols()[i] == "O":
-            charges[i] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
-
-    b = Ewald()
-    b.set(**ewald_beta_params)
-    atoms.calc = SumCalculator([b, PairPotential(calc_beta_cristobalite)])
-
-    FIRE(atoms, logfile=None).run(fmax=1e-2)
-
-    naForces_ana = atoms.calc.get_property('nonaffine_forces')
-    naForces_num = b.get_numerical_non_affine_forces(atoms, d=1e-5)
+    atoms = beta_cristobalite_bks
+    naForces_ana = atoms.calc.get_property("nonaffine_forces")
+    naForces_num = get_numerical_non_affine_forces(atoms, d=1e-5)
 
     print("Num: \n", naForces_num[:1])
     print("Ana: \n", naForces_ana[:1])
@@ -441,29 +399,23 @@ def test_non_affine_forces_beta_cristobalite():
     np.testing.assert_allclose(naForces_num, naForces_ana, atol=1e-2)
 
 
-def test_birch_coefficients_beta_cristobalite():
+@pytest.mark.parametrize("beta_cristobalite_bks", [6], indirect=True)
+def test_birch_coefficients_beta_cristobalite(beta_cristobalite_bks):
     """
     Test the computation of the affine elastic constants + stresses
     """
-    structure = beta_cristobalite()
-    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant=7)
-    charges = np.zeros(len(atoms))
-    for i in range(len(atoms)):
-        if atoms.get_chemical_symbols()[i] == "Si":
-            charges[i] = +2.4
-        elif atoms.get_chemical_symbols()[i] == "O":
-            charges[i] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
-
-    b = Ewald()
-    b.set(**ewald_beta_params)
-    atoms.calc = SumCalculator([b, PairPotential(calc_beta_cristobalite)])
-
-    FIRE(atoms, logfile=None).run(fmax=1e-2)
-
-    C_num, Cerr = fit_elastic_constants(atoms, symmetry="triclinic", N_steps=11, delta=1e-5, optimizer=None, verbose=False)
+    atoms = beta_cristobalite_bks
+    C_num, Cerr = fit_elastic_constants(
+        atoms,
+        symmetry="triclinic",
+        N_steps=11,
+        delta=1e-5,
+        optimizer=None,
+        verbose=False,
+    )
     C_ana = full_3x3x3x3_to_Voigt_6x6(
-        atoms.calc.get_property('birch_coefficients'), check_symmetry=False)
+        atoms.calc.get_property("birch_coefficients"), check_symmetry=False
+    )
 
     print("C_num: \n", C_num)
     print("C_ana: \n", C_ana)
@@ -471,34 +423,32 @@ def test_birch_coefficients_beta_cristobalite():
     np.testing.assert_allclose(C_num, C_ana, atol=1e-1)
 
 
-def test_non_affine_elastic_beta_cristobalite():
+@pytest.mark.parametrize("beta_cristobalite_bks", [6], indirect=True)
+def test_non_affine_elastic_beta_cristobalite(beta_cristobalite_bks):
     """
-    Test the computation of the affine elastic constants + stresses + non-affine elastic constants
+    Test the computation of the affine elastic constants + stresses
+    + non-affine elastic constants
     """
-    structure = beta_cristobalite()
-    atoms = structure(["Si", "O"], size=[1, 1, 1], latticeconstant=7)
-    charges = np.zeros(len(atoms))
-    for i in range(len(atoms)):
-        if atoms.get_chemical_symbols()[i] == "Si":
-            charges[i] = +2.4
-        elif atoms.get_chemical_symbols()[i] == "O":
-            charges[i] = -1.2
-    atoms.set_array("charge", charges, dtype=float)
-
-    b = Ewald()
-    b.set(**ewald_beta_params)
-    atoms.calc = SumCalculator([b, PairPotential(calc_beta_cristobalite)])
-
-    FIRE(ase.constraints.UnitCellFilter(atoms, mask=[1, 1, 1, 0, 0, 0]), logfile=None).run(fmax=1e-3)
-
-    C_num, Cerr = fit_elastic_constants(atoms, symmetry="triclinic", N_steps=11, delta=1e-3, optimizer=FIRE, fmax=1e-3, logfile=None, verbose=False)
+    atoms = beta_cristobalite_bks
+    C_num, Cerr = fit_elastic_constants(
+        atoms,
+        symmetry="triclinic",
+        N_steps=11,
+        delta=1e-3,
+        optimizer=FIRE,
+        fmax=1e-3,
+        logfile=None,
+        verbose=False,
+    )
     C_ana = full_3x3x3x3_to_Voigt_6x6(
-        atoms.calc.get_property('birch_coefficients'), check_symmetry=False)
+        atoms.calc.get_property("birch_coefficients"), check_symmetry=False
+    )
     C_na = full_3x3x3x3_to_Voigt_6x6(
-        get_non_affine_contribution_to_elastic_constants(atoms))
+        get_non_affine_contribution_to_elastic_constants(atoms)
+    )
 
     print("stress: \n", atoms.get_stress())
     print("C_num: \n", C_num)
     print("C_ana: \n", C_ana + C_na)
 
-    np.testing.assert_allclose(C_num, C_ana+C_na, atol=1e-1)
+    np.testing.assert_allclose(C_num, C_ana + C_na, atol=1e-1)


### PR DESCRIPTION
This PR splits Ewald summation from the BKS pair interaction. It makes Ewald inherit from PairPotential so the short-range Coulomb can use the pair code, and adds the kspace contributions.

Arbitrary pair interactions can now be used with the Ewald summation thanks to ASE's [`SumCalculator`](https://wiki.fysik.dtu.dk/ase/ase/calculators/mixing.html?highlight=sumcalculator#ase.calculators.mixing.SumCalculator). Getting properties like the hessian cannot be done with `get_hessian` if SumCalculator is used, but instead with the `get_property` method that subclasses of `ase.Calculator` should implement. For example, getting the hessian can now be done with `atoms.calc.get_property('hessian')`.