### PR TITLE
MAINT: added reporting of pytest results in CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,4 +32,10 @@ jobs:
     - name: pytest
       run: |
         cd tests
-        pytest -s --verbose
+        pytest -v --junitxml=report.xml --durations=20
+
+    - name: report
+      uses: mikepenz/action-junit-report@v2
+      if: always()
+      with:
+        report_paths: "**/report.xml"


### PR DESCRIPTION
I've setup the JUnitXML reporting of pytest results with github actions. This will make it easier to see which tests are failing and to get output per failed test.