### PR TITLE
BUG: change `set_axis_bgcolor` to `set_facecolor`

### DIFF
--- a/matscipy/elasticity.py
+++ b/matscipy/elasticity.py
@@ -829,7 +829,7 @@ def fit_elastic_constants(a, symmetry='triclinic', N_steps=5, delta=1e-2, optimi
 
             # colour the plot depending on the strain pattern
             colourDict = {0: '#BAD0EF', 1:'#FFCECE', 2:'#BDF4CB', 3:'#EEF093',4:'#FFA4FF',5:'#75ECFD'}
-            sp.set_axis_bgcolor(colourDict[patt])
+            sp.set_facecolor(colourDict[patt])
 
             # plot the data
             plt.plot([strain[0,index2],strain[-1,index2]],


### PR DESCRIPTION
To fix `AttributeError: 'AxesSubplot' object has no attribute 'set_axis_bgcolor'`

[The set_axis_bgcolor function was deprecated in version 2.0. Use set_facecolor instead.](https://matplotlib.org/2.1.2/api/_as_gen/matplotlib.axes.Axes.set_axis_bgcolor.html)