### PR TITLE
Documentation build fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Test compilation and publish documentation
+name: Build and publish documentation
 
 on:
   push:
@@ -23,19 +23,9 @@ jobs:
           sudo apt-get install -y python3-dev python3-pip libxml2-dev libxslt-dev zlib1g-dev meson
           sudo pip install --upgrade sphinxcontrib-napoleon sphinx_rtd_theme
 
-      - name: build
+      - name: install_package
         run: |
           sudo pip install .[test]
-
-      - name: pytest
-        run: |
-          cd tests
-          pytest -s --verbose
-
-      - name: package_dist
-        run: |
-          sudo pip install build
-          sudo python3 -m build . -s
 
       # Standard drop-in approach that should work for most people.
       - name: build_doc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,10 @@ jobs:
         run: |
           sudo apt-get update -qy
           sudo apt-get install -y python3-dev python3-pip libxml2-dev libxslt-dev zlib1g-dev meson
-          sudo pip install --upgrade sphinxcontrib-napoleon sphinx_rtd_theme
 
       - name: install_package
         run: |
-          sudo pip install .[test]
+          sudo pip install .[docs]
 
       # Standard drop-in approach that should work for most people.
       - name: build_doc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
-numpy>=1.5.0
-ase>=3.9.0
-#scipy>=0.10.0
-sphinxcontrib-napoleon
+numpy>=1.16.0
+ase>=3.16.0
 sphinx_rtd_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ test = [
     "pytest",
     "sympy"
 ]
+docs = [
+    "sphinx",
+    "sphinx-rtd-theme",
+]
 
 [project.urls]
 documentation = "http://libatoms.github.io/matscipy/"


### PR DESCRIPTION
The current workflow fails because the napoleon extension PyPI package is severely outdated. The up-to-date version is actually packaged with sphinx. I've also removed running tests in the doc building workflow, since we have a separate workflow for that.