### PR TITLE
Include new matscipy.precon module in meson build script

### DIFF
--- a/matscipy/meson.build
+++ b/matscipy/meson.build
@@ -28,6 +28,7 @@ python_sources = [
     'numerical.py',
     'numpy_tricks.py',
     'opls.py',
+    'precon.py',
     'pressurecoupling.py',
     'rings.py',
     'socketcalc.py',


### PR DESCRIPTION
Required following merge of #109 