### PR TITLE
BUG: Removed np.asscalar()

### DIFF
--- a/matscipy/fracture_mechanics/crack.py
+++ b/matscipy/fracture_mechanics/crack.py
@@ -1876,8 +1876,8 @@ def find_tip_coordination(a, bondlength=2.6, bulk_nn=4):
     a.set_array('above', above)
     a.set_array('below', below)
 
-    bond1 = np.asscalar(above.nonzero()[0][a.positions[above, 0].argmax()])
-    bond2 = np.asscalar(below.nonzero()[0][a.positions[below, 0].argmax()])
+    bond1 = above.nonzero()[0][a.positions[above, 0].argmax()]
+    bond2 = below.nonzero()[0][a.positions[below, 0].argmax()]
 
     # These need to be ints, otherwise they are no JSON serializable.
     a.info['bond1'] = bond1


### PR DESCRIPTION
np.asscalar no longer works since numpy 1.23.0. This breaks code which attempts to use crack.py (including the quasi-static fracture code). The fix implemented below is just removing the np.asscalar function call which fixes the error when tested.