### PR TITLE
move publishing of sdist tarball to build-wheels workflow 

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Check tag
         id: check-tag
         run: |
-          if [[ ${{ github.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ${{ github.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
               echo ::set-output name=match::true
           fi
         shell: bash
@@ -76,6 +76,12 @@ jobs:
         if: steps.check-tag.outputs.match == 'true'
         run: |
           pip install twine
+          if [ "$RUNNER_OS" == "Linux" ]; then
+               # build and upload sdist only once
+               pip install build
+               python -m build
+               twine upload dist/matscipy-*.tar.gz
+          fi
           twine upload wheelhouse/*.whl
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,10 +53,3 @@ jobs:
           branch: gh-pages
           directory: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish package
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Also widen scope of tag filter to release to PyPI also for release candidates