### PR TITLE
Collected documentation edits & fixes

### DIFF
--- a/docs/api/calculators.rst
+++ b/docs/api/calculators.rst
@@ -1,0 +1,4 @@
+Calculators
+-----------
+
+.. automodule:: matscipy.calculators

--- a/docs/api/dislocation.rst
+++ b/docs/api/dislocation.rst
@@ -1,0 +1,4 @@
+Dislocation
+----------
+
+.. automodule:: matscipy.dislocation

--- a/docs/api/elasticity.rst
+++ b/docs/api/elasticity.rst
@@ -1,0 +1,4 @@
+Elasticity
+----------
+
+.. automodule:: matscipy.elasticity

--- a/docs/api/fracture_mechanics.rst
+++ b/docs/api/fracture_mechanics.rst
@@ -1,0 +1,4 @@
+Fracture Mechanics
+------------------
+
+.. automodule:: matscipy.fracture_mechanics

--- a/docs/api/neighbours.rst
+++ b/docs/api/neighbours.rst
@@ -1,0 +1,4 @@
+Neighbour lists
+---------------
+
+.. automodule:: matscipy.neighbours

--- a/docs/api/numerical.rst
+++ b/docs/api/numerical.rst
@@ -1,0 +1,4 @@
+Numerical
+---------
+
+.. automodule:: matscipy.numerical

--- a/docs/api/root.rst
+++ b/docs/api/root.rst
@@ -1,0 +1,4 @@
+Matscipy root
+-------------
+
+.. automodule:: matscipy

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -1,0 +1,10 @@
+API Reference
+=============
+
+.. toctree::
+   ./api/root
+   ./api/calculators
+   ./api/elasticity
+   ./api/neighbours
+   ./api/numerical
+   ./api/fracture_mechanics

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -8,3 +8,4 @@ API Reference
    ./api/neighbours
    ./api/numerical
    ./api/fracture_mechanics
+   ./api/dislocation

--- a/docs/calculators.rst
+++ b/docs/calculators.rst
@@ -1,0 +1,5 @@
+Calculators
+===========
+
+Here's a description of the calculators available in `matscipy` and how they can
+be composed.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -270,3 +270,14 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+# -- Extension configuration -------------------------------------------------
+
+autodoc_default_options = {
+    'members': True,
+    'member-order': 'bysource',
+    'undoc-members': True,
+    'show-inheritance': True,
+    'inherited-members': True,
+    'special-members': '__init__',
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,8 +26,9 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('../'))
+
+# sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('../'))
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/elastic_constants.rst
+++ b/docs/elastic_constants.rst
@@ -1,0 +1,4 @@
+Elastic Constants
+=================
+
+Here's how to use `matscipy` to evaluate elastic constants of an RVE.

--- a/docs/fracture_mechanics.rst
+++ b/docs/fracture_mechanics.rst
@@ -1,0 +1,4 @@
+Fracture Mechanics
+==================
+
+Here's what you can do with Matscipy in the field of fracture mechanics.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@
 
    ./calculators
    ./fracture_mechanics
+   ./plasticity
    ./elastic_constants
    ./api_reference
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,37 +6,48 @@
 .. include:: ../README.rst
 
 
-Contents
-========
+..
+   Matscipy submodules
+   ===================
 
-.. autosummary::
+   .. autosummary::
 
-   matscipy.angle_distribution
-   matscipy.atomic_strain
-   matscipy.calculators
-   matscipy.calculators.eam
-   matscipy.calculators.pair_potential
-   matscipy.calculators.mcfm
-   matscipy.calculators.supercell_calculator
-   matscipy.calculators.manybody
-   matscipy.contact_mechanics
-   matscipy.contact_mechanics.DMT
-   matscipy.contact_mechanics.greens_function
-   matscipy.contact_mechanics.Hertz
-   matscipy.contact_mechanics.JKR
-   matscipy.elasticity
-   matscipy.fracture_mechanics
-   matscipy.fracture_mechanics.clusters
-   matscipy.fracture_mechanics.crack
-   matscipy.fracture_mechanics.crackpathsel
-   matscipy.fracture_mechanics.energy_release
-   matscipy.fracture_mechanics.idealbrittlesolid
-   matscipy.hydrogenate
-   matscipy.io
-   matscipy.logger
-   matscipy.neighbours
-   matscipy.rings
-   matscipy.surface
+      matscipy.angle_distribution
+      matscipy.atomic_strain
+      matscipy.calculators
+      matscipy.calculators.eam
+      matscipy.calculators.pair_potential
+      matscipy.calculators.mcfm
+      matscipy.calculators.supercell_calculator
+      matscipy.calculators.manybody
+      matscipy.contact_mechanics
+      matscipy.contact_mechanics.DMT
+      matscipy.contact_mechanics.greens_function
+      matscipy.contact_mechanics.Hertz
+      matscipy.contact_mechanics.JKR
+      matscipy.elasticity
+      matscipy.fracture_mechanics
+      matscipy.fracture_mechanics.clusters
+      matscipy.fracture_mechanics.crack
+      matscipy.fracture_mechanics.crackpathsel
+      matscipy.fracture_mechanics.energy_release
+      matscipy.fracture_mechanics.idealbrittlesolid
+      matscipy.hydrogenate
+      matscipy.io
+      matscipy.logger
+      matscipy.neighbours
+      matscipy.numerical
+      matscipy.rings
+      matscipy.surface
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Table of Contents:
+
+   ./calculators
+   ./fracture_mechanics
+   ./elastic_constants
+   ./api_reference
 
 
 Indices and tables

--- a/docs/plasticity.rst
+++ b/docs/plasticity.rst
@@ -1,0 +1,4 @@
+Plasticity
+==========
+
+Here's what you can do with Matscipy in the field of plasticity.


### PR DESCRIPTION
I propose to edit/add documentation on this pull request. I've made a split into "API Reference" for autodoc-generated submodule API documentation, and top-level "user guides" for the parts of matscipy that might need tutorials (similar to how ASE does things in its own documentation). Feel free to edit and discuss changes.

**Important note**
The meson build broke the generation of documentation directly from the source because the `_version.py` module is now automatically generated by meson, so matscipy *must first be installed with pip* before documentation is generated. A reinstall is also required on source edits. I have not made changes to the CI to fix this problem, but I plan on fixing that in this PR.