### PR TITLE
added FCC dislocations to dislocation module

### DIFF
--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -33,7 +33,6 @@ from ase.build import bulk
 from ase.calculators.lammpslib import LAMMPSlib
 from ase.units import GPa  # unit conversion
 from ase.io import read
-from ase.geometry import get_distances
 
 from matscipy.neighbours import neighbour_list, mic
 from matscipy.elasticity import fit_elastic_constants
@@ -62,7 +61,7 @@ def make_screw_cyl(alat, C11, C12, C44,
         radius of cylinder of unconstrained atoms around the
         dislocation  in angstrom
     cutoff : float
-        Potential cutoff for marinica potentials for FS cutoff = 4.4
+        Potential cutoff for Marinica potentials for FS cutoff = 4.4
     hard_core : bool
         Description of parameter `hard_core`.
     center : type
@@ -208,17 +207,17 @@ def make_edge_cyl(alat, C11, C12, C44,
     cylinder_r - radius of cylinder of unconstrained atoms around the
                  dislocation  in angstrom
 
-    cutoff - potential cutoff for marinica potentials for FS cutoff = 4.4
+    cutoff - potential cutoff for Marinica potentials for FS cutoff = 4.4
 
     symbol : string
-        Symbol of the element to pass to ase.lattuce.cubic.SimpleCubicFactory
+        Symbol of the element to pass to ase.lattice.cubic.SimpleCubicFactory
         default is "W" for tungsten
     '''
     from atomman import ElasticConstants
     from atomman.defect import Stroh
-    # Create a Stroh ojbect with junk data
+    # Create a Stroh object with junk data
     stroh = Stroh(ElasticConstants(C11=141, C12=110, C44=98),
-                                   np.array([0, 0, 1]))
+                  np.array([0, 0, 1]))
 
     axes = np.array([[1, 1, 1],
                      [1, -1, 0],
@@ -238,7 +237,7 @@ def make_edge_cyl(alat, C11, C12, C44,
 
     bulk = unit_cell.copy()
 
-    # shift to make the zeros of the cell betweem the atomic planes
+    # shift to make the zeros of the cell between the atomic planes
     # and under the midplane on Y axes
     X_midplane_shift = (1.0/3.0)*alat*np.sqrt(3.0)/2.0
     Y_midplane_shift = 0.25*alat*np.sqrt(2.0)
@@ -254,7 +253,7 @@ def make_edge_cyl(alat, C11, C12, C44,
     Lx = int(round(tot_r/(alat*np.sqrt(3.0)/2.0)))
     Ly = int(round(tot_r/(alat*np.sqrt(2.))))
 
-    # factor 2 to make shure odd number of images is translated
+    # factor 2 to make sure odd number of images is translated
     # it is important for the correct centering of the dislocation core
     bulk = bulk * (2*Lx, 2*Ly, 1)
 
@@ -292,7 +291,7 @@ def make_edge_cyl(alat, C11, C12, C44,
     # move lower left segment
     bulk.positions[(y < 0.0) & (x < X_midplane_shift)] -= \
         [alat * np.sqrt(3.0) / 2.0, 0.0, 0.0]
-    # make the doslocation extraplane center
+    # make the dislocation extra half plane center
     bulk.positions += [(1.0/3.0)*alat*np.sqrt(3.0)/2.0, 0.0, 0.0]
 
     return ED, bulk
@@ -309,7 +308,7 @@ def plot_vitek(dislo, bulk,
     bulk : ase.Atoms
         Corresponding bulk configuration for calculation of displacements.
     alat : float
-        Lattice parameter for calculation of neghbour list cutoff.
+        Lattice parameter for calculation of neighbour list cutoff.
     plot_axes : matplotlib.Axes.axes object
         Existing axes to plot on, allows to pass existing matplotlib axes
         have full control of the graph outside the function.
@@ -336,8 +335,8 @@ def plot_vitek(dislo, bulk,
 
     neighborListCutoff = 0.95 * alat
 
-    # plot window is +-10 angstroms from center in x,y directions, and one Burgers vector
-    # thickness along z direction
+    # plot window is +-10 angstroms from center in x,y directions,
+    # and one Burgers vector thickness along z direction
     x, y, _ = bulk.positions.T
 
     plot_range = np.array([[x.mean() - xyscale, x.mean() + xyscale],
@@ -348,14 +347,15 @@ def plot_vitek(dislo, bulk,
     # distance between atoms on the plot
     plot_scale = 1.885618083
 
-    fig = differential_displacement(base_system, disl_system,
-                                    burgers,
-                                    cutoff=neighborListCutoff,
-                                    xlim=plot_range[0],
-                                    ylim=plot_range[1],
-                                    zlim=plot_range[2],
-                                    matplotlib_axes=plot_axes,
-                                    plot_scale=plot_scale)
+    _ = differential_displacement(base_system, disl_system,
+                                  burgers,
+                                  cutoff=neighborListCutoff,
+                                  xlim=plot_range[0],
+                                  ylim=plot_range[1],
+                                  zlim=plot_range[2],
+                                  matplotlib_axes=plot_axes,
+                                  plot_scale=plot_scale)
+
 
 def show_NEB_configurations(images, bulk, xyscale=7,
                             show=True, core_positions=None):
@@ -452,7 +452,7 @@ def get_elastic_constants(pot_path=None,
     pot_path - path to the potential
 
     symbol : string
-        Symbol of the element to pass to ase.lattuce.cubic.SimpleCubicFactory
+        Symbol of the element to pass to ase.lattice.cubic.SimpleCubicFactory
         default is "W" for tungsten
     """
 
@@ -467,15 +467,17 @@ def get_elastic_constants(pot_path=None,
 
     unit_cell.calc = calculator
 
-#   simple calculation to get the lattice constant and cohesive energy
-#    alat0 = W.cell[0][1] - W.cell[0][0]
-    sf = StrainFilter(unit_cell)  # or UnitCellFilter(W) -> to minimise wrt pos, cell
+    #   simple calculation to get the lattice constant and cohesive energy
+    #    alat0 = W.cell[0][1] - W.cell[0][0]
+    sf = StrainFilter(unit_cell)
+    # or UnitCellFilter(W)
+    # -> to minimise wrt pos, cell
     opt = FIRE(sf)
     opt.run(fmax=1e-4)  # max force in eV/A
     alat = unit_cell.cell[0][1] - unit_cell.cell[0][0]
-#    print("a0 relaxation %.4f --> %.4f" % (a0, a))
-#    e_coh = W.get_potential_energy()
-#    print("Cohesive energy %.4f" % e_coh)
+    #    print("a0 relaxation %.4f --> %.4f" % (a0, a))
+    #    e_coh = W.get_potential_energy()
+    #    print("Cohesive energy %.4f" % e_coh)
 
     Cij, Cij_err = fit_elastic_constants(unit_cell,
                                          symmetry="cubic",
@@ -591,11 +593,15 @@ def make_barrier_configurations(elastic_param=None,
 
     return disloc_ini, disloc_fin, bulk_ini
 
-def make_screw_cyl_kink(alat, C11, C12, C44,
-                        cylinder_r=40, kink_length=26, kind="double", **kwargs):
-    """Function to create kink configuration based on make_screw_cyl() function.
-        Double kink configuration is in agreement with quadrupoles in terms of formation energy.
-        Single kink configurations provide correct and stable structure, but formation energy is not accessible?
+
+def make_screw_cyl_kink(alat, C11, C12, C44, cylinder_r=40,
+                        kink_length=26, kind="double", **kwargs):
+    """
+    Function to create kink configuration based on make_screw_cyl() function.
+    Double kink configuration is in agreement with
+    quadrupoles in terms of formation energy.
+    Single kink configurations provide correct and stable structure,
+    but formation energy is not accessible?
 
     Parameters
     ----------
@@ -629,8 +635,11 @@ def make_screw_cyl_kink(alat, C11, C12, C44,
     b = np.sqrt(3.0) * alat / 2.0
     cent_x = np.sqrt(6.0) * alat / 3.0
 
-    disloc_ini, disloc_fin, bulk_ini = make_barrier_configurations((alat, C11, C12, C44),
-                                                                    cylinder_r=cylinder_r, **kwargs)
+    disloc_ini, \
+        disloc_fin, \
+        bulk_ini = make_barrier_configurations((alat, C11, C12, C44),
+                                               cylinder_r=cylinder_r,
+                                               **kwargs)
 
     if kind == "double":
 
@@ -688,7 +697,8 @@ def make_screw_cyl_kink(alat, C11, C12, C44,
         cell[2][2] -= 2.0 * b / 3.0
         kink.set_cell(cell, scale_atoms=False)
 
-        # make sure all the atoms are removed and cell is modified for the bulk as well.
+        # make sure all the atoms are removed and cell is modified
+        # for the bulk as well.
         large_bulk.cell[2][0] += cent_x
         large_bulk.cell[2][2] -= 2.0 * b / 3.0
         large_bulk = large_bulk[right_kink_mask]
@@ -725,7 +735,8 @@ def make_screw_cyl_kink(alat, C11, C12, C44,
         cell[2][2] -= 1.0 * b / 3.0
         kink.set_cell(cell, scale_atoms=False)
 
-        # make sure all the atoms are removed and cell is modified for the bulk as well.
+        # make sure all the atoms are removed and cell is modified
+        # for the bulk as well.
         large_bulk.cell[2][0] -= cent_x
         large_bulk.cell[2][2] -= 1.0 * b / 3.0
         large_bulk = large_bulk[left_kink_mask]
@@ -737,8 +748,10 @@ def make_screw_cyl_kink(alat, C11, C12, C44,
 
     return kink, reference_straight_disloc, large_bulk
 
+
 def slice_long_dislo(kink, kink_bulk, b):
-    """Function to slice a long dislocation configuration to perform dislocation structure and core position analysis
+    """Function to slice a long dislocation configuration to perform
+       dislocation structure and core position analysis
 
     Parameters
     ----------
@@ -1282,7 +1295,7 @@ def screw_cyl_octahedral(alat, C11, C12, C44,
 
     # Create a Stroh object with junk data
     stroh = Stroh(ElasticConstants(C11=141, C12=110, C44=98),
-                                   np.array([0, 0, 1]))
+                  np.array([0, 0, 1]))
 
     c = ElasticConstants(C11=C11, C12=C12, C44=C44)
     burgers = alat * np.array([1., 1., 1.])/2.
@@ -1336,8 +1349,6 @@ def dipole_displacement_angle(W_bulk, dislo_coord_left, dislo_coord_right,
         Generates a simple displacement field for two dislocations in a dipole
         configuration uding simple Voltera solution as u = b/2 * angle
     """
-
-
     burgers = W_bulk.cell[2][2]
 
     shifted_positions = W_bulk.positions + shift - dislo_coord_left
@@ -1379,7 +1390,7 @@ def get_u_img(W_bulk,
                 u_img += dipole_displacement_angle(W_bulk,
                                                    dislo_coord_left + shift,
                                                    dislo_coord_right + shift,
-                                                   shift=n2_shift*C2_quadrupole + n1_shift*C1_quadrupole)
+                                                   shift=n2_shift * C2_quadrupole + n1_shift * C1_quadrupole)
 
     return u_img
 
@@ -1519,8 +1530,8 @@ def make_screw_quadrupole(alat,
     """
 
     unit_cell = BodyCenteredCubic(directions=[[1, -2, 1],
-                                      [2, -1, -1],
-                                      [1, 1, 1]],
+                                              [2, -1, -1],
+                                              [1, 1, 1]],
                                   symbol=symbol,
                                   pbc=(True, True, True),
                                   latticeconstant=alat, debug=0)
@@ -1691,10 +1702,12 @@ def make_screw_quadrupole(alat,
     return disloc_quadrupole, bulk, dislo_coord_left, dislo_coord_right
 
 
-def make_screw_quadrupole_kink(alat, kind="double", n1u=5, kink_length=20, symbol="W"):
+def make_screw_quadrupole_kink(alat, kind="double",
+                               n1u=5, kink_length=20, symbol="W"):
     """Generates kink configuration using make_screw_quadrupole() function
        works for BCC structure.
-       The method is based on paper https://doi.org/10.1016/j.jnucmat.2008.12.053
+       The method is based on paper
+       https://doi.org/10.1016/j.jnucmat.2008.12.053
 
     Parameters
     ----------
@@ -1703,7 +1716,8 @@ def make_screw_quadrupole_kink(alat, kind="double", n1u=5, kink_length=20, symbo
     kind : string
         kind of the kink: right, left or double
     n1u : int
-        Number of lattice vectors for the quadrupole cell (make_screw_quadrupole() function)
+        Number of lattice vectors for the quadrupole cell
+        (make_screw_quadrupole() function)
     kink_length : int
         Length of the cell per kink along b in unit of b, must be even.
     symbol : string
@@ -1725,15 +1739,17 @@ def make_screw_quadrupole_kink(alat, kind="double", n1u=5, kink_length=20, symbo
     b = np.sqrt(3.0) * alat / 2.0
     cent_x = np.sqrt(6.0) * alat / 3.0
 
-    ini_disloc_quadrupole, W_bulk, _, _ = make_screw_quadrupole(alat, n1u=n1u,
-                                                                   left_shift=0.0,
-                                                                   right_shift=0.0,
-                                                                   symbol=symbol)
+    ini_disloc_quadrupole, \
+        W_bulk, _, _ = make_screw_quadrupole(alat, n1u=n1u,
+                                             left_shift=0.0,
+                                             right_shift=0.0,
+                                             symbol=symbol)
 
-    fin_disloc_quadrupole, W_bulk, _, _ = make_screw_quadrupole(alat, n1u=n1u,
-                                                                   left_shift=1.0,
-                                                                   right_shift=1.0,
-                                                                   symbol=symbol)
+    fin_disloc_quadrupole, \
+        W_bulk, _, _ = make_screw_quadrupole(alat, n1u=n1u,
+                                             left_shift=1.0,
+                                             right_shift=1.0,
+                                             symbol=symbol)
 
     reference_straight_disloc = ini_disloc_quadrupole * [1, 1, kink_length]
     large_bulk = W_bulk * [1, 1, kink_length]
@@ -1754,7 +1770,8 @@ def make_screw_quadrupole_kink(alat, kind="double", n1u=5, kink_length=20, symbo
         kink.cell[2][2] += upper_kink.cell[2][2]
         kink.extend(upper_kink)
 
-        # left kink is created the kink vector is in negative x direction assuming (x, y, z) is right group of vectors
+        # left kink is created the kink vector is in negative x direction
+        # assuming (x, y, z) is right group of vectors
         kink = kink[left_kink_mask]
         kink.cell[2][0] -= cent_x
         kink.cell[2][2] -= 1.0 * b / 3.0
@@ -1796,7 +1813,8 @@ def make_screw_quadrupole_kink(alat, kind="double", n1u=5, kink_length=20, symbo
 
         kink.cell[2][2] += upper_kink.cell[2][2]
 
-        large_bulk = W_bulk * [1, 1, 2 * kink_length]  # double kink is double length
+        # double kink is double length
+        large_bulk = W_bulk * [1, 1, 2 * kink_length]
 
     else:
         raise ValueError('Kind must be "right", "left" or "double"')
@@ -2115,7 +2133,8 @@ def get_centering_mask(atoms, radius,
 
 def check_duplicates(atoms, distance=0.1):
     """
-    Returns a mask of atoms that have at least one other atom closer than distance
+    Returns a mask of atoms that have at least
+    one other atom closer than distance
     """
     mask = atoms.get_all_distances() < distance
     duplicates = np.full_like(atoms, False)
@@ -2193,12 +2212,10 @@ class CubicCrystalDislocation:
         c = ElasticConstants(C11=self.C11, C12=self.C12, C44=self.C44)
         self.stroh = Stroh(c, burgers=self.burgers, axes=self.axes)
 
-
     def set_burgers(self, burgers):
         self.burgers = burgers
         if self.stroh is None:
             self.init_stroh()
-
 
     def plot_unit_cell(self, ms=250, ax=None):
         import matplotlib.pyplot as plt
@@ -2220,7 +2237,7 @@ class CubicCrystalDislocation:
                 [0.0, y0, y0, 0.0, 0.0], color="black", zorder=0)
 
         bulk_atoms = ax.scatter([], [], color="w", edgecolor="k",
-                             label="lattice atoms")
+                                label="lattice atoms")
         core1 = ax.scatter([], [], marker="x", label="initial core position",
                            c="r")
         core2 = ax.scatter([], [], marker="x", label="glide core position",
@@ -2230,8 +2247,7 @@ class CubicCrystalDislocation:
         ax.set_xlabel(r"$\AA$")
         ax.set_ylabel(r"$\AA$")
 
-
-    def displacements(self, bulk_positions, center, self_consistent=True, 
+    def displacements(self, bulk_positions, center, self_consistent=True,
                       tol=1e-6, max_iter=100, verbose=True):
         if self.stroh is None:
             self.init_stroh()
@@ -2251,7 +2267,8 @@ class CubicCrystalDislocation:
                 print('disloc SCF', i, '|d1-d2|_inf =', res)
             i += 1
             if i > max_iter:
-                raise RuntimeError(f'Self-consistency did not converge in {max_iter} cycles')
+                raise RuntimeError('Self-consistency' +
+                                   f'did not converge in {max_iter} cycles')
         return disp2
 
     def build_cylinder(self, radius,
@@ -2271,7 +2288,7 @@ class CubicCrystalDislocation:
         repeat_extension = np.floor(2.0 * extension /
                                     np.diag(self.unit_cell.cell)).astype(int)
         repeat_core_position = np.floor(2.0 * core_position /
-                                    np.diag(self.unit_cell.cell)).astype(int)
+                                        np.diag(self.unit_cell.cell)).astype(int)
 
         extra_repeat = np.stack((repeat_core_position,
                                  repeat_extension)).max(axis=0)
@@ -2294,7 +2311,8 @@ class CubicCrystalDislocation:
         center = np.diag(bulk.cell) / 2
         shifted_center = center + core_position
 
-        cylinder_mask = get_centering_mask(bulk, radius, core_position, extension)
+        cylinder_mask = get_centering_mask(bulk, radius,
+                                           core_position, extension)
 
         # add square borders for the case of large extension or core position
         x, y, _ = bulk.positions.T
@@ -2406,7 +2424,7 @@ class CubicCrystalDislocation:
         repeat_extension = np.floor(extension /
                                     np.diag(self.unit_cell.cell)).astype(int)
         repeat_core_position = np.floor(core_position /
-                                    np.diag(self.unit_cell.cell)).astype(int)
+                                        np.diag(self.unit_cell.cell)).astype(int)
 
         extra_repeat = np.stack((repeat_core_position,
                                  repeat_extension)).max(axis=0)
@@ -2459,8 +2477,8 @@ class CubicCrystalDislocation:
         non_core_mask = np.logical_not(core_mask)
 
         displacemets = self.displacements(impurities_bulk.positions[non_core_mask],
-                                                          shifted_center,
-                                                          self_consistent=self_consistent)
+                                          shifted_center,
+                                          self_consistent=self_consistent)
 
         impurities_disloc.positions[non_core_mask] += displacemets
 
@@ -2487,6 +2505,7 @@ class CubicCrystalDislocation:
 
         return impurities_disloc
 
+
 class BCCScrew111Dislocation(CubicCrystalDislocation):
     def __init__(self, alat, C11, C12, C44, symbol='W'):
         axes = np.array([[1, 1, -2],
@@ -2505,7 +2524,7 @@ class BCCScrew111Dislocation(CubicCrystalDislocation):
                          axes, burgers, unit_cell_core_position, parity,
                          glide_distance)
 
-        
+
 class BCCEdge111Dislocation(CubicCrystalDislocation):
     def __init__(self, alat, C11, C12, C44, symbol='W'):
         axes = np.array([[1, 1, 1],
@@ -2513,7 +2532,7 @@ class BCCEdge111Dislocation(CubicCrystalDislocation):
                          [1, 1, -2]])
         burgers = alat * np.array([1, 1, 1]) / 2.0
         unit_cell_core_position = alat * np.array([(1.0/3.0) * np.sqrt(3.0)/2.0,
-                                  0.25 * np.sqrt(2.0), 0])
+                                                  0.25 * np.sqrt(2.0), 0])
         parity = [0, 0]
         unit_cell = BodyCenteredCubic(directions=axes.tolist(),
                                       size=(1, 1, 1), symbol=symbol,
@@ -2680,7 +2699,6 @@ class CubicCrystalDissociatedDislocation(CubicCrystalDislocation):
 
         super().__init__(*args, **kwargs)
 
-
     def build_cylinder(self, radius, partial_distance=0,
                        core_position=np.array([0., 0., 0.]),
                        extension=np.array([0., 0., 0.]),
@@ -2707,16 +2725,16 @@ class CubicCrystalDissociatedDislocation(CubicCrystalDislocation):
             [self.glide_distance * partial_distance, 0.0, 0.0])
 
         bulk, disloc = self.left_dislocation.build_cylinder(radius,
-                                                  extension=extension + partial_distance_Angstrom,
-                                                  core_position=core_position,
-                                                  fix_width=fix_width,
-                                                  self_consistent=self_consistent)
+                                                            extension=extension + partial_distance_Angstrom,
+                                                            core_position=core_position,
+                                                            fix_width=fix_width,
+                                                            self_consistent=self_consistent)
 
         _, disloc_right = self.right_dislocation.build_cylinder(radius,
-                                                      core_position=core_position + partial_distance_Angstrom,
-                                                      extension=extension,
-                                                      fix_width=fix_width,
-                                                      self_consistent=self_consistent)
+                                                                core_position=core_position + partial_distance_Angstrom,
+                                                                extension=extension,
+                                                                fix_width=fix_width,
+                                                                self_consistent=self_consistent)
 
         u_right = disloc_right.positions - bulk.positions
         disloc.positions += u_right
@@ -2756,7 +2774,7 @@ class DiamondGlideScrew(CubicCrystalDissociatedDislocation):
         left30 = DiamondGlide30degreePartial(alat, C11, C12, C44)
         left30.set_burgers(burgers_left)
         # another 30 degree
-        burgers_right = alat * np.array([1, -2, 1.]) / 6.
+        # burgers_right = alat * np.array([1, -2, 1.]) / 6. - default value
         right30 = DiamondGlide30degreePartial(alat, C11, C12, C44)
         self_consistent = False
         super().__init__(left30, right30, unit_cell, alat, C11, C12, C44,
@@ -2796,7 +2814,7 @@ class DiamondGlide60Degree(CubicCrystalDissociatedDislocation):
         left30 = DiamondGlide30degreePartial(alat, C11, C12, C44)
         left30.set_burgers(burgers_left)
         # 90 degree
-        burgers_right = alat * np.array([1, 1, -2.]) / 6.
+        # burgers_right = alat * np.array([1, 1, -2.]) / 6. - default value
         right90 = DiamondGlide90degreePartial(alat, C11, C12, C44)
         self_consistent = False
         super().__init__(left30, right90, unit_cell, alat, C11, C12, C44,
@@ -2816,14 +2834,18 @@ class FCCScrewShockleyPartial(CubicCrystalDislocation):
         parity = [0, 0]
 
         unit_cell = FaceCenteredCubic(symbol, directions=axes.tolist(),
-                                     pbc=(False, False, True),
-                                     latticeconstant=alat)
+                                      pbc=(False, False, True),
+                                      latticeconstant=alat)
 
         # put the dislocation in the centroid of the first triangle in xy plane
         # get sorting of the atoms in the distance of atoms in xy plane
-        sorted_indices = np.argsort(np.linalg.norm(unit_cell.positions[:, :2], axis=1))
-        # centroid coordinates are simply mean of x y coordinates of the trianlge
-        disloCenterX, disloCenterY, _ = unit_cell.positions[sorted_indices[:3]].mean(axis=0)
+        sorted_indices = np.argsort(np.linalg.norm(unit_cell.positions[:, :2],
+                                                   axis=1))
+        # centroid coordinates are simply
+        # mean of x y coordinates of the trianlge
+        disloCenterX, \
+            disloCenterY, \
+            _ = unit_cell.positions[sorted_indices[:3]].mean(axis=0)
 
         unit_cell_core_position = np.array([disloCenterX,
                                             disloCenterY, 0])
@@ -2869,7 +2891,7 @@ class FCCScrew110Dislocation(CubicCrystalDissociatedDislocation):
         left_shockley = FCCScrewShockleyPartial(alat, C11, C12, C44)
         left_shockley.set_burgers(burgers_left)
         # another Shockley partial
-        # burgers_right = alat * np.array([1, -2, 1.]) / 6.
+        # burgers_right = alat * np.array([1, -2, 1.]) / 6. - default value
         right_shockley = FCCScrewShockleyPartial(alat, C11, C12, C44)
         self_consistent = True
         super().__init__(left_shockley, right_shockley,
@@ -2984,7 +3006,8 @@ def gamma_line(unit_cell, calc=None, shift_dir=0, surface=2,
 
         if image.get_forces().max() < fmax:
             raise RuntimeError(
-                "Initial max force is smaller than fmax! Check surface direction")
+                "Initial max force is smaller than fmax!" +
+                "Check surface direction")
 
         if relax:
             opt = LBFGSLineSearch(image)

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -456,7 +456,7 @@ def get_elastic_constants(pot_path=None,
         default is "W" for tungsten
     """
 
-    unit_cell = bulk(symbol)
+    unit_cell = bulk(symbol, cubic=True)
 
     if (pot_path is not None) and (calculator is None):
         # create lammps calculator with the potential
@@ -474,7 +474,7 @@ def get_elastic_constants(pot_path=None,
     # -> to minimise wrt pos, cell
     opt = FIRE(sf)
     opt.run(fmax=1e-4)  # max force in eV/A
-    alat = unit_cell.cell[0][1] - unit_cell.cell[0][0]
+    alat = unit_cell.cell.lengths()[0]
     #    print("a0 relaxation %.4f --> %.4f" % (a0, a))
     #    e_coh = W.get_potential_energy()
     #    print("Cohesive energy %.4f" % e_coh)

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -2838,6 +2838,47 @@ class FCCScrewShockleyPartial(CubicCrystalDislocation):
                          self_consistent=self_consistent)
 
 
+class FCCScrew110Dislocation(CubicCrystalDissociatedDislocation):
+    def __init__(self, alat, C11, C12, C44, symbol='Fe'):
+
+        axes = np.array([[1, 1, -2],
+                        [1, 1, 1],
+                        [1, -1, 0]])
+
+        # aiming for the resulting burgers vector
+        burgers = alat * np.array([1, -1, 0]) / 2.
+
+        disloCenterX = 0.5 * (alat * np.linalg.norm(axes[0])) / 4.0
+        disloCenterY = (alat * np.linalg.norm(axes[1])) / 6
+
+        unit_cell_core_position = np.array([disloCenterX,
+                                            disloCenterY, 0])
+
+        parity = [0, 0]
+
+        unit_cell = FaceCenteredCubic(symbol, directions=axes.tolist(),
+                                      pbc=(False, False, True),
+                                      latticeconstant=alat)
+
+        glide_distance = alat * np.linalg.norm(axes[0]) / 4.0
+
+        n_planes = 2
+
+        # Shockley partial
+        burgers_left = alat * np.array([2., -1., -1.]) / 6.
+        left_shockley = FCCScrewShockleyPartial(alat, C11, C12, C44)
+        left_shockley.set_burgers(burgers_left)
+        # another Shockley partial
+        # burgers_right = alat * np.array([1, -2, 1.]) / 6.
+        right_shockley = FCCScrewShockleyPartial(alat, C11, C12, C44)
+        self_consistent = True
+        super().__init__(left_shockley, right_shockley,
+                         unit_cell, alat, C11, C12, C44,
+                         axes, burgers, unit_cell_core_position, parity,
+                         glide_distance, n_planes=n_planes,
+                         self_consistent=self_consistent)
+
+
 class FixedLineAtoms:
     """Constrain atoms to move along a given direction only."""
     def __init__(self, a, direction):

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -2901,6 +2901,37 @@ class FCCScrew110Dislocation(CubicCrystalDissociatedDislocation):
                          self_consistent=self_consistent)
 
 
+class FCCEdgeShockleyPartial(CubicCrystalDislocation):
+    def __init__(self, alat, C11, C12, C44, symbol='Fe'):
+        axes = np.array([[1, -1, 0],
+                         [1, 1, 1],
+                         [-1, -1, 2]])
+
+        burgers = alat * np.array([1, -2, 1.]) / 6.
+
+        parity = [0, 0]
+
+        unit_cell = FaceCenteredCubic(symbol, directions=axes.tolist(),
+                                      pbc=(False, False, True),
+                                      latticeconstant=alat)
+
+        disloCenterX = 0.0
+        # middle between two (111) planes
+        disloCenterY = unit_cell.cell[1][1] / 6.0
+
+        unit_cell_core_position = np.array([disloCenterX,
+                                            disloCenterY, 0])
+
+        glide_distance = alat * np.linalg.norm(axes[0]) / 4.0
+
+        n_planes = 6
+        self_consistent = True
+        super().__init__(unit_cell, alat, C11, C12, C44,
+                         axes, burgers, unit_cell_core_position, parity,
+                         glide_distance, n_planes=n_planes,
+                         self_consistent=self_consistent)
+
+
 class FixedLineAtoms:
     """Constrain atoms to move along a given direction only."""
     def __init__(self, a, direction):

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -1,6 +1,6 @@
 #
 # Copyright 2019, 2021 Lars Pastewka (U. Freiburg)
-#           2018-2021 Petr Grigorev (Warwick U.)
+#           2018-2023 Petr Grigorev (Warwick U.)
 #           2020 James Kermode (Warwick U.)
 #           2019 Arnaud Allera (U. Lyon 1)
 #           2019 Wolfram G. Nöhring (U. Freiburg)
@@ -2685,14 +2685,22 @@ class DiamondGlide90degreePartial(CubicCrystalDislocation):
 
 
 class CubicCrystalDissociatedDislocation(CubicCrystalDislocation):
-    """
-        This class represents a dissociated dislocation in a cubic crystal
-        with b = b_left + b_right.
-        'left_dislocation' and 'right_dislocations' are expected
-        to be instances of classes derived from CubicCrystalDislocation class.
-    """
     def __init__(self, left_dislocation, right_dislocation, burgers):
+        """This class represents a dissociated dislocation in a cubic crystal
+        with burgers vercor b = b_left + b_right.
 
+        Args:
+            left_dislocation (CubicCrystalDislocation): dislocation with b_left
+            right_dislocation (CubicCrystalDislocation): dislocation with b_right
+            burgers (ndarray of 3 floats): resulting burgers vector
+
+        Raises:
+            ValueError: If resulting burgers vector
+                        burgers is not a sum of burgers vectors of
+                        left and right dislocations.
+            ValueError: If one of the properties of
+                        left and righ dislocations are not the same.
+        """
         try:
             np.testing.assert_almost_equal(left_dislocation.burgers +
                                            right_dislocation.burgers,

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -2932,6 +2932,52 @@ class FCCEdgeShockleyPartial(CubicCrystalDislocation):
                          self_consistent=self_consistent)
 
 
+class FCCEdge110Dislocation(CubicCrystalDissociatedDislocation):
+    def __init__(self, alat, C11, C12, C44, symbol='Fe'):
+
+        axes = np.array([[1, -1, 0],
+                         [1, 1, 1],
+                         [-1, -1, 2]])
+
+        # aiming for the resulting burgers vector
+        burgers = alat * np.array([1, -1, 0]) / 2.
+
+        unit_cell = FaceCenteredCubic(symbol, directions=axes.tolist(),
+                                      pbc=(False, False, True),
+                                      latticeconstant=alat)
+
+        disloCenterX = 0.0
+        # middle between two (111) planes
+        disloCenterY = unit_cell.cell[1][1] / 6.0
+
+        unit_cell_core_position = np.array([disloCenterX,
+                                            disloCenterY, 0])
+
+        parity = [0, 0]
+
+        unit_cell = FaceCenteredCubic(symbol, directions=axes.tolist(),
+                                      pbc=(False, False, True),
+                                      latticeconstant=alat)
+
+        glide_distance = alat * np.linalg.norm(axes[0]) / 4.0
+
+        n_planes = 6
+
+        # Shockley partial
+        burgers_left = alat * np.array([2., -1., -1.]) / 6.
+        left_shockley = FCCEdgeShockleyPartial(alat, C11, C12, C44)
+        left_shockley.set_burgers(burgers_left)
+        # another Shockley partial
+        # burgers_right = alat * np.array([1, -2, 1.]) / 6. - default value
+        right_shockley = FCCEdgeShockleyPartial(alat, C11, C12, C44)
+        self_consistent = True
+        super().__init__(left_shockley, right_shockley,
+                         unit_cell, alat, C11, C12, C44,
+                         axes, burgers, unit_cell_core_position, parity,
+                         glide_distance, n_planes=n_planes,
+                         self_consistent=self_consistent)
+
+
 class FixedLineAtoms:
     """Constrain atoms to move along a given direction only."""
     def __init__(self, a, direction):

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -2741,6 +2741,25 @@ class CubicCrystalDissociatedDislocation(CubicCrystalDislocation):
 
         return bulk, disloc
 
+    def displacements(self, bulk_positions, center,
+                      partial_distance=0, **kwargs):
+        """Overloaded function to provide correct displacements
+        for the dissociated dislocation.
+        Partial distance is provided as an integer to define number
+        of glide distances between two partials.
+        """
+
+        partial_distance_Angstrom = np.array(
+            [self.glide_distance * partial_distance, 0.0, 0.0])
+
+        left_u = self.left_dislocation.displacements(bulk_positions, center,
+                                                     **kwargs)
+        right_u = self.right_dislocation.displacements(bulk_positions,
+                                                       center + partial_distance_Angstrom,
+                                                       **kwargs)
+
+        return left_u + right_u
+
 
 class DiamondGlideScrew(CubicCrystalDissociatedDislocation):
     def __init__(self, alat, C11, C12, C44, symbol='C'):

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -521,6 +521,14 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
                           structure="FCC", test_u=False,
                           burgers=(1.0 / 2.0) * np.array([0.0, 1.0, 1.0]))
 
+    @unittest.skipIf("atomman" not in sys.modules or
+                     "ovito" not in sys.modules,
+                     "requires atomman and ovito")
+    def test_fcc_edge_shockley_partial_dislocation(self,):
+        self.check_disloc(sd.FCCEdgeShockleyPartial, 60.0,
+                          structure="FCC",
+                          burgers=(1.0 / 6.0) * np.array([1.0, 2.0, 1.0]))
+
     def check_glide_configs(self, cls, structure="BCC"):
         alat = 3.14339177996466
         C11 = 523.0266819809012
@@ -695,6 +703,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
 
         np.testing.assert_almost_equal(E, target_E, decimal=3)
         np.testing.assert_almost_equal(shift, target_shift, decimal=3)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -648,6 +648,13 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         self.check_glide_configs(sd.FCCEdgeShockleyPartial,
                                  structure="FCC")
 
+    @unittest.skipIf("atomman" not in sys.modules or
+                     "ovito" not in sys.modules,
+                     "requires atomman and ovito")
+    def test_fcc_edge_dislocation_glide(self):
+        self.check_glide_configs(sd.FCCEdge110Dislocation,
+                                 structure="FCC")
+
     def test_fixed_line_atoms(self):
 
         from ase.build import bulk

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -96,10 +96,10 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
     def test_elastic_constants_EAM(self):
         """Test the get_elastic_constants()
            function using matscipy EAM calculator."""
-        target_values = np.array([3.14339177996466,  # alat
-                                  523.0266819809012,  # C11
-                                  202.1786296941397,  # C12
-                                  160.88179872237012])  # C44 for eam4
+        target_values = np.array([3.1433,  # alat
+                                  523.03,  # C11
+                                  202.18,  # C12
+                                  160.88])  # C44 for eam4
 
         pot_name = "w_eam4.fs"
         pot_path = os.path.join(test_dir, pot_name)
@@ -107,7 +107,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         obtained_values = sd.get_elastic_constants(calculator=calc_EAM,
                                                    delta=1.0e-3)
 
-        self.assertArrayAlmostEqual(obtained_values, target_values, tol=1e-4)
+        self.assertArrayAlmostEqual(obtained_values, target_values, tol=1e-2)
 
     # This function tests the lammpslib and LAMMPS installation
     # skipped during automated testing
@@ -121,10 +121,10 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         """
         print("WARNING: In case lammps crashes no error message is printed: ",
               "check 'lammps.log' file in test folder")
-        target_values = np.array([3.14339177996466,  # alat
-                                  523.0266819809012,  # C11
-                                  202.1786296941397,  # C12
-                                  160.88179872237012])  # C44 for eam4
+        target_values = np.array([3.1434,  # alat
+                                  523.03,  # C11
+                                  202.18,  # C12
+                                  160.882])  # C44 for eam4
 
         pot_name = "w_eam4.fs"
         pot_path = os.path.join(test_dir, pot_name)
@@ -138,7 +138,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
 
         os.remove("lammps.log")
 
-        self.assertArrayAlmostEqual(obtained_values, target_values, tol=1e-4)
+        self.assertArrayAlmostEqual(obtained_values, target_values, tol=1e-2)
 
     # This function tests the lammpslib and LAMMPS installation
     # skipped during automated testing

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -494,7 +494,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
                      "requires atomman and ovito")
     def test_screw_diamond_dislocation(self,):
         self.check_disloc(sd.DiamondGlideScrew, 0.0,
-                          structure="Diamond", test_u=False,
+                          structure="Diamond",
                           burgers=(1.0 / 2.0) * np.array([0.0, 1.0, 1.0]))
 
     @unittest.skipIf("atomman" not in sys.modules or
@@ -502,7 +502,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
                      "requires atomman and ovito")
     def test_60degree_diamond_dislocation(self,):
         self.check_disloc(sd.DiamondGlide60Degree, 60.0,
-                          structure="Diamond", test_u=False,
+                          structure="Diamond",
                           burgers=(1.0 / 2.0) * np.array([1.0, 0.0, 1.0]))
 
     @unittest.skipIf("atomman" not in sys.modules or
@@ -518,7 +518,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
                      "requires atomman and ovito")
     def test_fcc_screw110_dislocation(self,):
         self.check_disloc(sd.FCCScrew110Dislocation, 0.0,
-                          structure="FCC", test_u=False,
+                          structure="FCC",
                           burgers=(1.0 / 2.0) * np.array([0.0, 1.0, 1.0]))
 
     @unittest.skipIf("atomman" not in sys.modules or
@@ -534,7 +534,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
                      "requires atomman and ovito")
     def test_fcc_edge110_partial_dislocation(self,):
         self.check_disloc(sd.FCCEdge110Dislocation, 90.0,
-                          structure="FCC", test_u=False,
+                          structure="FCC",
                           burgers=(1.0 / 2.0) * np.array([1.0, 1.0, 0.0]))
 
     def check_glide_configs(self, cls, structure="BCC"):

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -469,7 +469,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         self.check_disloc(sd.DiamondGlide60Degree, 60.0,
                           structure="Diamond", test_u=False,
                           burgers=(1.0 / 2.0) * np.array([1.0, 0.0, 1.0]))
-        
+
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
@@ -477,6 +477,14 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         self.check_disloc(sd.FCCScrewShockleyPartial, 30.0,
                           structure="FCC",
                           burgers=(1.0 / 6.0) * np.array([1.0, 2.0, 1.0]))
+
+    @unittest.skipIf("atomman" not in sys.modules or
+                     "ovito" not in sys.modules,
+                     "requires atomman and ovito")
+    def test_fcc_screw110_dislocation(self,):
+        self.check_disloc(sd.FCCScrew110Dislocation, 0.0,
+                          structure="FCC", test_u=False,
+                          burgers=(1.0 / 2.0) * np.array([0.0, 1.0, 1.0]))
 
     def check_glide_configs(self, cls, structure="BCC"):
         alat = 3.14339177996466

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -561,7 +561,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
-    def test_screw_diamond_partial_glide(self):
+    def test_screw_diamond_glide(self):
             self.check_glide_configs(sd.DiamondGlideScrew,
                                      structure="Diamond")
 
@@ -569,7 +569,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
-    def test_60degree_diamond_partial_glide(self):
+    def test_60degree_diamond_glide(self):
             self.check_glide_configs(sd.DiamondGlide60Degree,
                                      structure="Diamond")
 

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -529,6 +529,14 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
                           structure="FCC",
                           burgers=(1.0 / 6.0) * np.array([1.0, 2.0, 1.0]))
 
+    @unittest.skipIf("atomman" not in sys.modules or
+                     "ovito" not in sys.modules,
+                     "requires atomman and ovito")
+    def test_fcc_edge110_partial_dislocation(self,):
+        self.check_disloc(sd.FCCEdge110Dislocation, 90.0,
+                          structure="FCC", test_u=False,
+                          burgers=(1.0 / 2.0) * np.array([1.0, 1.0, 0.0]))
+
     def check_glide_configs(self, cls, structure="BCC"):
         alat = 3.14339177996466
         C11 = 523.0266819809012
@@ -631,6 +639,13 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
                      "requires atomman and ovito")
     def test_fcc_screw_110_glide(self):
         self.check_glide_configs(sd.FCCScrew110Dislocation,
+                                 structure="FCC")
+
+    @unittest.skipIf("atomman" not in sys.modules or
+                     "ovito" not in sys.modules,
+                     "requires atomman and ovito")
+    def test_fcc_edge_shockley_partial_glide(self):
+        self.check_glide_configs(sd.FCCEdgeShockleyPartial,
                                  structure="FCC")
 
     def test_fixed_line_atoms(self):

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -31,6 +31,8 @@ from ase.calculators.lammpslib import LAMMPSlib
 from scipy.optimize import minimize
 from matscipy.calculators.eam import EAM
 
+test_dir = os.path.dirname(os.path.realpath(__file__))
+
 try:
     import matplotlib
     matplotlib.use("Agg")  # Activate 'agg' backend for off-screen plotting for testing.
@@ -99,7 +101,8 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
                                   160.88179872237012])  # C44 for eam4
 
         pot_name = "w_eam4.fs"
-        calc_EAM = EAM(pot_name)
+        pot_path = os.path.join(test_dir, pot_name)
+        calc_EAM = EAM(pot_path)
         obtained_values = sd.get_elastic_constants(calculator=calc_EAM,
                                                    delta=1.0e-3)
 
@@ -122,9 +125,9 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
                                   160.88179872237012])  # C44 for eam4
 
         pot_name = "w_eam4.fs"
-
+        pot_path = os.path.join(test_dir, pot_name)
         lammps = LAMMPSlib(lmpcmds=["pair_style eam/fs",
-                                    "pair_coeff * * %s W" % pot_name],
+                                    "pair_coeff * * %s W" % pot_path],
                            atom_types={'W': 1}, keep_alive=True,
                            log_file="lammps.log")
 
@@ -159,10 +162,11 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         center = (cent_x, 0.0, 0.0)
 
         pot_name = "w_eam4.fs"
+        pot_path = os.path.join(test_dir, pot_name)
         target_toten = -13086.484626  # Target value for w_eam4
 
         lammps = LAMMPSlib(lmpcmds=["pair_style eam/fs",
-                                    "pair_coeff * * %s W" % pot_name],
+                                    "pair_coeff * * %s W" % pot_path],
                            atom_types={'W': 1}, keep_alive=True,
                            log_file="lammps.log")
 
@@ -566,7 +570,8 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         from ase.build import bulk
 
         pot_name = "w_eam4.fs"
-        calc_EAM = EAM(pot_name)
+        pot_path = os.path.join(test_dir, pot_name)
+        calc_EAM = EAM(pot_path)
         # slightly pressurised cell to avoid exactly zero forces
         W = bulk("W", a=0.9 * 3.143392, cubic=True)
 
@@ -603,9 +608,10 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         unit_cell = dislocation.unit_cell
 
         pot_name = "w_eam4.fs"
+        pot_path = os.path.join(test_dir, pot_name)
         # calc_EAM = EAM(pot_name) eam calculator is way too slow
         lammps = LAMMPSlib(lmpcmds=["pair_style eam/fs",
-                                    "pair_coeff * * %s W" % pot_name],
+                                    "pair_coeff * * %s W" % pot_path],
                            atom_types={'W': 1}, keep_alive=True,
                            log_file="lammps.log")
 

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -469,6 +469,14 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         self.check_disloc(sd.DiamondGlide60Degree, 60.0,
                           structure="Diamond", test_u=False,
                           burgers=(1.0 / 2.0) * np.array([1.0, 0.0, 1.0]))
+        
+    @unittest.skipIf("atomman" not in sys.modules or
+                     "ovito" not in sys.modules,
+                     "requires atomman and ovito")
+    def test_fcc_shockley_partial_dislocation(self,):
+        self.check_disloc(sd.FCCScrewShockleyPartial, 30.0,
+                          structure="FCC",
+                          burgers=(1.0 / 6.0) * np.array([1.0, 2.0, 1.0]))
 
     def check_glide_configs(self, cls, structure="BCC"):
         alat = 3.14339177996466

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -416,8 +416,13 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         C12 = 202.1786296941397
         C44 = 160.88179872237012
 
-        d = cls(alat, C11, C12, C44)
+        d = cls(alat, C11, C12, C44, symbol="Al")
         bulk, disloc = d.build_cylinder(20.0)
+
+        # test that assigning non default symbol worked
+        assert np.unique(bulk.get_chemical_symbols()) == "Al"
+        assert np.unique(disloc.get_chemical_symbols()) == "Al"
+
         assert len(bulk) == len(disloc)
 
         if test_u:

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -588,6 +588,12 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
             self.check_glide_configs(sd.FCCScrewShockleyPartial,
                                      structure="FCC")
 
+    @unittest.skipIf("atomman" not in sys.modules or
+                     "ovito" not in sys.modules,
+                     "requires atomman and ovito")
+    def test_fcc_screw_110_glide(self):
+            self.check_glide_configs(sd.FCCScrew110Dislocation,
+                                     structure="FCC")
 
     def test_fixed_line_atoms(self):
 

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -28,7 +28,6 @@ import matscipy.dislocation as sd
 import numpy as np
 
 from ase.calculators.lammpslib import LAMMPSlib
-from scipy.optimize import minimize
 from matscipy.calculators.eam import EAM
 
 test_dir = os.path.dirname(os.path.realpath(__file__))
@@ -58,7 +57,8 @@ except ImportError:
 class TestDislocation(matscipytest.MatSciPyTestCase):
     """Class to store test for dislocation.py module."""
 
-    @unittest.skipIf("atomman" not in sys.modules, 'requires Stroh solution from atomman to run')
+    @unittest.skipIf("atomman" not in sys.modules,
+                     'requires Stroh solution from atomman to run')
     def test_core_position(self):
         """Make screw dislocation and fit a core position to it.
 
@@ -94,7 +94,8 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         self.assertArrayAlmostEqual(core_pos, initial_guess + center[:2], tol=1e-4)
 
     def test_elastic_constants_EAM(self):
-        """Test the get_elastic_constants() function using matscipy EAM calculator."""
+        """Test the get_elastic_constants()
+           function using matscipy EAM calculator."""
         target_values = np.array([3.14339177996466,  # alat
                                   523.0266819809012,  # C11
                                   202.1786296941397,  # C12
@@ -108,7 +109,8 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
 
         self.assertArrayAlmostEqual(obtained_values, target_values, tol=1e-4)
 
-    # This function tests the lammpslib and LAMMPS installation and thus skipped during automated testing
+    # This function tests the lammpslib and LAMMPS installation
+    # skipped during automated testing
     @unittest.skipIf("lammps" not in sys.modules,
                      "LAMMPS installation is required and thus is not good for automated testing")
     def test_elastic_constants_lammpslib(self):
@@ -138,7 +140,8 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
 
         self.assertArrayAlmostEqual(obtained_values, target_values, tol=1e-4)
 
-    # This function tests the lammpslib and LAMMPS installation and thus skipped during automated testing
+    # This function tests the lammpslib and LAMMPS installation
+    # skipped during automated testing
     @unittest.skipIf("lammps" not in sys.modules or
                      "atomman" not in sys.modules,
                      "LAMMPS installation and Stroh solution are required")
@@ -216,7 +219,8 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         print("'dd_test.png' will be created: check the displacement map")
         fig.savefig("dd_test.png")
 
-    @unittest.skipIf("atomman" not in sys.modules, 'requires Stroh solution from atomman to run')
+    @unittest.skipIf("atomman" not in sys.modules,
+                     'requires Stroh solution from atomman to run')
     def test_read_dislo_QMMM(self):
         """Test read_dislo_QMMM() function"""
 
@@ -259,13 +263,17 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
             total_Nat_type += Nat_type
             self.assertEqual(Nat_type, target_values[atom_type])
 
-        self.assertEqual(Nat, total_Nat_type)  # total number of atoms in region is equal to Nat (no atoms unmapped)
+        # total number of atoms in region is equal to Nat (no atoms unmapped)
+        self.assertEqual(Nat, total_Nat_type)
         # TODO
-        #  self.assertAtomsAlmostEqual(disloc, test_disloc) - gives an error of _cell attribute new ase version?
+        # self.assertAtomsAlmostEqual(disloc, test_disloc) -
+        # gives an error of _cell attribute new ase version?
 
-    @unittest.skipIf("atomman" not in sys.modules, 'requires Stroh solution from atomman to run')
+    @unittest.skipIf("atomman" not in sys.modules,
+                     'requires Stroh solution from atomman to run')
     def test_stroh_solution(self):
-        """Builds isotropic Stroh solution and compares it to Volterra solution"""
+        """Builds isotropic Stroh solution
+        and compares it to Volterra solution"""
 
         alat = 3.14
         C11 = 523.0
@@ -274,7 +282,8 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
 
         # A = 2. * C44 / (C11 - C12)
         # print(A) # A = 0.999937 very isotropic material.
-        # At values closer to 1.0 Stroh solution is numerically unstable and does not pass checks
+        # At values closer to 1.0 Stroh solution is numerically unstable
+        # and does not pass checks
         cylinder_r = 40
         burgers = alat * np.sqrt(3.0) / 2.
 
@@ -287,26 +296,32 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         u_volterra = np.arctan2(y, x) * burgers / (2.0 * np.pi)
 
         # compare x and y components with zeros - isotropic solution
-        self.assertArrayAlmostEqual(np.zeros_like(u_volterra), u_stroh[:, 0], tol=1e-4)
-        self.assertArrayAlmostEqual(np.zeros_like(u_volterra), u_stroh[:, 1], tol=1e-4)
+        self.assertArrayAlmostEqual(np.zeros_like(u_volterra), u_stroh[:, 0],
+                                    tol=1e-4)
+        self.assertArrayAlmostEqual(np.zeros_like(u_volterra), u_stroh[:, 1],
+                                    tol=1e-4)
         #  compare z component with simple Volterra solution
         self.assertArrayAlmostEqual(u_volterra, u_stroh[:, 2])
 
     def test_make_screw_quadrupole_kink(self):
-        """Test the total number of atoms in the quadrupole double kink configuration"""
+        """Test the total number of atoms in the quadrupole
+            double kink configuration"""
 
         alat = 3.14
         n1u = 5
         kink_length = 20
 
-        kink, _, _ = sd.make_screw_quadrupole_kink(alat=alat, n1u=n1u, kink_length=kink_length)
+        kink, _, _ = sd.make_screw_quadrupole_kink(alat=alat, n1u=n1u,
+                                                   kink_length=kink_length)
         quadrupole_base, _, _, _ = sd.make_screw_quadrupole(alat=alat, n1u=n1u)
 
         self.assertEqual(len(kink), len(quadrupole_base) * 2 * kink_length)
 
-    @unittest.skipIf("atomman" not in sys.modules, 'requires Stroh solution from atomman to run')
+    @unittest.skipIf("atomman" not in sys.modules,
+                     'requires Stroh solution from atomman to run')
     def test_make_screw_cyl_kink(self):
-        """Test the total number of atoms and number of fixed atoms in the cylinder double kink configuration"""
+        """Test the total number of atoms and number of fixed atoms
+            in the cylinder double kink configuration"""
 
         alat = 3.14339177996466
         C11 = 523.0266819809012
@@ -319,11 +334,19 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         cylinder_r = 40
         kink_length = 26
 
-        kink, large_disloc, straight_bulk = sd.make_screw_cyl_kink(alat, C11, C12, C44, kink_length=kink_length,
-                                                                   cylinder_r=cylinder_r, kind="double")
+        kink, \
+            large_disloc, _ = sd.make_screw_cyl_kink(alat,
+                                                     C11,
+                                                     C12,
+                                                     C44,
+                                                     kink_length=kink_length,
+                                                     cylinder_r=cylinder_r,
+                                                     kind="double")
 
         # check the total number of atoms as compared to make_screw_cyl()
-        disloc, _, _ = sd.make_screw_cyl(alat, C11, C12, C12, cylinder_r=cylinder_r, l_extend=center)
+        disloc, _, _ = sd.make_screw_cyl(alat, C11, C12, C12,
+                                         cylinder_r=cylinder_r,
+                                         l_extend=center)
 
         self.assertEqual(len(kink), len(disloc) * 2 * kink_length)
 
@@ -345,12 +368,15 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         n1u = 5
         kink_length = 20
 
-        kink, straight_dislo, kink_bulk = sd.make_screw_quadrupole_kink(alat=alat, n1u=n1u, kink_length=kink_length)
+        kink, _, kink_bulk = sd.make_screw_quadrupole_kink(alat=alat,
+                                                           n1u=n1u,
+                                                           kink_length=kink_length)
         quadrupole_base, _, _, _ = sd.make_screw_quadrupole(alat=alat, n1u=n1u)
 
         sliced_kink, core_positions = sd.slice_long_dislo(kink, kink_bulk, b)
 
-        # check the number of sliced configurations is equal to length of 2 * kink_length * 3 (for double kink)
+        # check the number of sliced configurations is equal
+        # to length of 2 * kink_length * 3 (for double kink)
         self.assertEqual(len(sliced_kink), kink_length * 3 * 2)
 
         # check that the bulk and kink slices are the same size
@@ -361,16 +387,26 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         # check that the size of slices are the same as single b configuration
         self.assertArrayAlmostEqual(len(quadrupole_base), len(sliced_kink[0][0]))
 
-        right_kink, straight_dislo, kink_bulk = sd.make_screw_quadrupole_kink(alat=alat, n1u=n1u, kind="right",
-                                                                              kink_length=kink_length)
+        right_kink, _, \
+            kink_bulk = sd.make_screw_quadrupole_kink(alat=alat,
+                                                      n1u=n1u,
+                                                      kind="right",
+                                                      kink_length=kink_length)
+
         sliced_right_kink, _ = sd.slice_long_dislo(right_kink, kink_bulk, b)
-        # check the number of sliced configurations is equal to length of kink_length * 3 - 2 (for right kink)
+        # check the number of sliced configurations is equal
+        # to length of kink_length * 3 - 2 (for right kink)
         self.assertEqual(len(sliced_right_kink), kink_length * 3 - 2)
 
-        left_kink, straight_dislo, kink_bulk = sd.make_screw_quadrupole_kink(alat=alat, n1u=n1u, kind="left",
-                                                                              kink_length=kink_length)
+        left_kink, _, \
+            kink_bulk = sd.make_screw_quadrupole_kink(alat=alat,
+                                                      n1u=n1u,
+                                                      kind="left",
+                                                      kink_length=kink_length)
+
         sliced_left_kink, _ = sd.slice_long_dislo(left_kink, kink_bulk, b)
-        # check the number of sliced configurations is equal to length of kink_length * 3 - 1 (for left kink)
+        # check the number of sliced configurations is equal
+        # to length of kink_length * 3 - 1 (for left kink)
         self.assertEqual(len(sliced_left_kink), kink_length * 3 - 1)
 
     def check_disloc(self, cls, ref_angle, structure="BCC", test_u=True,
@@ -393,7 +429,8 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
 
             displacement = disloc.positions - bulk.positions
 
-            np.testing.assert_array_almost_equal(displacement, stroh_displacement)
+            np.testing.assert_array_almost_equal(displacement,
+                                                 stroh_displacement)
 
         results = sd.ovito_dxa_straight_dislo_info(disloc, structure=structure)
         assert len(results) == 1
@@ -404,16 +441,16 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         print(f'angle = {angle} ref_angle = {ref_angle} err = {err}')
         assert abs(err) < tol
 
-    @unittest.skipIf("atomman" not in sys.modules or 
+    @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
     def test_screw_dislocation(self):
         self.check_disloc(sd.BCCScrew111Dislocation, 0.0)
 
-    @unittest.skipIf("atomman" not in sys.modules or 
+    @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
-    def test_edge_dislocation(self):        
+    def test_edge_dislocation(self):
         self.check_disloc(sd.BCCEdge111Dislocation, 90.0)
 
     @unittest.skipIf("atomman" not in sys.modules or
@@ -430,7 +467,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         self.check_disloc(sd.BCCEdge100110Dislocation, 90.0,
                           burgers=np.array([1.0, 0.0, 0.0]))
 
-    @unittest.skipIf("atomman" not in sys.modules or 
+    @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
     def test_mixed_dislocation(self):
@@ -452,7 +489,6 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
                           structure="Diamond",
                           burgers=(1.0 / 6.0) * np.array([2.0, 1.0, 1.0]))
 
-
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
@@ -460,7 +496,6 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         self.check_disloc(sd.DiamondGlideScrew, 0.0,
                           structure="Diamond", test_u=False,
                           burgers=(1.0 / 2.0) * np.array([0.0, 1.0, 1.0]))
-
 
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
@@ -542,58 +577,53 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
     def test_edge100_glide(self):
         self.check_glide_configs(sd.BCCEdge100Dislocation)
 
-
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
     def test_edge100110_glide(self):
-            self.check_glide_configs(sd.BCCEdge100110Dislocation)
-
+        self.check_glide_configs(sd.BCCEdge100110Dislocation)
 
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
     def test_30degree_diamond_partial_glide(self):
-            self.check_glide_configs(sd.DiamondGlide30degreePartial,
-                                     structure="Diamond")
-
+        self.check_glide_configs(sd.DiamondGlide30degreePartial,
+                                 structure="Diamond")
 
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
     def test_90degree_diamond_partial_glide(self):
-            self.check_glide_configs(sd.DiamondGlide90degreePartial,
-                                     structure="Diamond")
-
+        self.check_glide_configs(sd.DiamondGlide90degreePartial,
+                                 structure="Diamond")
 
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
     def test_screw_diamond_glide(self):
-            self.check_glide_configs(sd.DiamondGlideScrew,
-                                     structure="Diamond")
-
+        self.check_glide_configs(sd.DiamondGlideScrew,
+                                 structure="Diamond")
 
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
     def test_60degree_diamond_glide(self):
-            self.check_glide_configs(sd.DiamondGlide60Degree,
-                                     structure="Diamond")
+        self.check_glide_configs(sd.DiamondGlide60Degree,
+                                 structure="Diamond")
 
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
     def test_fcc_screw_shockley_partial_glide(self):
-            self.check_glide_configs(sd.FCCScrewShockleyPartial,
-                                     structure="FCC")
+        self.check_glide_configs(sd.FCCScrewShockleyPartial,
+                                 structure="FCC")
 
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
     def test_fcc_screw_110_glide(self):
-            self.check_glide_configs(sd.FCCScrew110Dislocation,
-                                     structure="FCC")
+        self.check_glide_configs(sd.FCCScrew110Dislocation,
+                                 structure="FCC")
 
     def test_fixed_line_atoms(self):
 
@@ -627,9 +657,9 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
             # forces on unconstrained atoms are non zero
             assert (W.get_forces()[~fixed_mask] != 0.0).all()
 
-
     @unittest.skipIf("lammps" not in sys.modules,
-                     "LAMMPS installation is required and thus is not good for automated testing")
+                     "LAMMPS installation is required and " +
+                     "thus is not good for automated testing")
     def test_gamma_line(self):
 
         # eam_4 parameters

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -33,6 +33,7 @@ from matscipy.calculators.eam import EAM
 
 try:
     import matplotlib
+    matplotlib.use("Agg")  # Activate 'agg' backend for off-screen plotting for testing.
 except ImportError:
     print("matplotlib not found: skipping some tests")
 

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -473,7 +473,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
     @unittest.skipIf("atomman" not in sys.modules or
                      "ovito" not in sys.modules,
                      "requires atomman and ovito")
-    def test_fcc_shockley_partial_dislocation(self,):
+    def test_fcc_screw_shockley_partial_dislocation(self,):
         self.check_disloc(sd.FCCScrewShockleyPartial, 30.0,
                           structure="FCC",
                           burgers=(1.0 / 6.0) * np.array([1.0, 2.0, 1.0]))
@@ -505,8 +505,8 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         # test that difference between initial and final positions are
         # roughly equal to glide distance.
         # Since the configurations are unrelaxed dxa gives
-        # a very rough estimation (especially for edge dislcoations)
-        # thus tolerance is taken to be ~1 Angstom
+        # a very rough estimation (especially for edge dislocations)
+        # thus tolerance is taken to be ~1 Angstrom
         np.testing.assert_almost_equal(fin_x_position - ini_x_position,
                                        d.glide_distance, decimal=0)
 
@@ -572,6 +572,14 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
     def test_60degree_diamond_partial_glide(self):
             self.check_glide_configs(sd.DiamondGlide60Degree,
                                      structure="Diamond")
+
+    @unittest.skipIf("atomman" not in sys.modules or
+                     "ovito" not in sys.modules,
+                     "requires atomman and ovito")
+    def test_fcc_screw_shockley_partial_glide(self):
+            self.check_glide_configs(sd.FCCScrewShockleyPartial,
+                                     structure="FCC")
+
 
     def test_fixed_line_atoms(self):
 


### PR DESCRIPTION
The main enhancement is the addition of 1/2<110>{111} edge and screw dislocations in FCC. In FCC these dislocations dissociate into two 1/6<112>{111} Shockley partials as for example: 1/2[1-10] = 1/6<2-1-1> + ISF + 1/6<1-21>.
The implementation includes:
- `FCCScrewShockleyPartial` - Shockley screw partial
- `FCCScrew110Dislocation` - dissociated <110> screw dislocation
- `FCCEdgeShockleyPartial` - Shockley edge partial
- `FCCEdge110Dislocation` - dissociated <110> edge dislocation

I also added relevant test and fixed few bugs. `CubicCrystalDissociatedDislocation` was significantly reworked. Now it checks that provided partials have same properties and the sum of the burgers vectors results in the desired value. After that the properties of the resulting dislocation are taken from one of the partials. It makes the code more readable and robust. 