### PR TITLE
Make sure that l is rotated into the x direction.

### DIFF
--- a/matscipy/elasticity.py
+++ b/matscipy/elasticity.py
@@ -1100,7 +1100,7 @@ def elastic_moduli(C, l=np.array([1, 0, 0]), R=None, tol=1e-6):
         u_b = np.array([1, 0, 0])
         R = np.eye(3)
 
-        if not np.allclose(l, u_a, rtol=tol, atol=tol):
+        if not np.allclose(l, u_b, rtol=tol, atol=tol):
             u_v = np.cross(u_a, u_b)
             u_v_mat = np.array([[ 0,      -u_v[2], u_v[1]],
                                 [ u_v[2], 0,      -u_v[0]],

--- a/matscipy/elasticity.py
+++ b/matscipy/elasticity.py
@@ -1096,8 +1096,8 @@ def elastic_moduli(C, l=np.array([1, 0, 0]), R=None, tol=1e-6):
                               np.eye(3, dtype=float)) > tol):
             raise RuntimeError('Matrix *R* does not describe a rotation.')
     else:
-        u_a = np.array([1, 0, 0])
-        u_b = l/norm(l)  # Normalise directions
+        u_a = l/norm(l)  # Normalise directions
+        u_b = np.array([1, 0, 0])
         R = np.eye(3)
 
         if not np.allclose(l, u_a, rtol=tol, atol=tol):

--- a/tests/test_elastic_moduli.py
+++ b/tests/test_elastic_moduli.py
@@ -83,6 +83,24 @@ def test_rotation():
             np.testing.assert_array_almost_equal(G, EM[i]['G'], decimal=9)
 
 
+def test_monoclinic():
+    C = np.array([
+            [5,2,2,0,1,0],
+            [2,5,2,0,1,0],
+            [2,2,5,0,1,0],
+            [0,0,0,2,0,1],
+            [1,1,1,0,2,0],
+            [0,0,0,1,0,2]
+        ])
+    l = [np.array([1, 0, 1]), np.array([1, 0, -1])]
+    EM = np.array([5.4545,3.1579])
+
+    for i, directions in enumerate(l):
+        directions = directions / np.linalg.norm(directions)
+        E, nu, Gm, B, K = elastic_moduli(C, l=directions)
+        np.testing.assert_almost_equal(E[0], EM[i], decimal=1)
+
+
 ###
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #152

Tested against ELATE: https://progs.coudert.name/elate

Minimal example:
```python
from matscipy.elasticity import elastic_moduli
import numpy as np

# dummy monoclinic system
# [1,0,1] is not equivalent to [1,0,-1]
C = np.array([[5,2,2,0,1,0],
              [2,5,2,0,1,0],
              [2,2,5,0,1,0],
              [0,0,0,2,0,1],
              [1,1,1,0,2,0],
              [0,0,0,1,0,2]])

# Young's moduli in [1,0,1]  and [1,0,-1]  cartesian direction
# ELATE predicts [1,0,1] is larger than [1,0,-1]
# elastic_moduli() does the opposite
# What appears to be happening, is that elastic_moduli()
# rotates the [1,0,0] direction into [1,0,1], rather than
# [1,0,1] into [1,0,0]. This means that the [1,0,-1] is 
# now aligned with [1,0,0]. This okay in high symmetry cases
# where [1,0,1] is equivalent to [1,0,-1], but not here.
E, nu, Gm, B, K = elastic_moduli(C,[1,0,1])
print("[1,0,1] :", E[0])
E, nu, Gm, B, K = elastic_moduli(C,[1,0,-1])
print("[1,0,-1]:", E[0])
```
