### PR TITLE
Make sure only normalized vectors are compared.

### DIFF
--- a/matscipy/elasticity.py
+++ b/matscipy/elasticity.py
@@ -1100,7 +1100,7 @@ def elastic_moduli(C, l=np.array([1, 0, 0]), R=None, tol=1e-6):
         u_b = np.array([1, 0, 0])
         R = np.eye(3)
 
-        if not np.allclose(l, u_b, rtol=tol, atol=tol):
+        if np.abs(np.dot(u_a, u_b)) < 1.0 - tol:
             u_v = np.cross(u_a, u_b)
             u_v_mat = np.array([[ 0,      -u_v[2], u_v[1]],
                                 [ u_v[2], 0,      -u_v[0]],


### PR DESCRIPTION
If we want to avoid rotating x into itself, we have to catch unnormalized versions of it, e.g., [2,0,0] is the same as [1,0,0]. This situation was not caught.

Alternatively, we might consider replace the allclose() solutation by a dot product, i.e., np.abs(np.dot(u_a,u_b)) < tol because the current solution still crashes when l = [-1,0,0], which is physically the same as [1,0,0] as far as elastic properties are concerned.