### PR TITLE
always return array of length maxlength

### DIFF
--- a/matscipy/rings.py
+++ b/matscipy/rings.py
@@ -50,4 +50,12 @@ def ring_statistics(a, cutoff, maxlength=-1):
     """
     i, j, r = neighbour_list('ijD', a, cutoff)
     d = distances_on_graph(i, j)
+
+    if maxlength > 0:
+        ringstat = np.zeros(maxlength)
+        rs = find_sp_rings(i, j, r, d, maxlength)
+        ringstat[:len(rs)] += rs
+    else:
+        ringstat = find_sp_rings(i, j, r, d, maxlength)
+
     return find_sp_rings(i, j, r, d, maxlength)


### PR DESCRIPTION
The size of the array returned by matscipy.rings.ring_statistics depends on the structure that the ring statistics were computed for, i.e. the largest ring found (limited by maxlength). For example, the ring statistics returned for a graphene sheet would always be [0, 0, 0, 0, 0, n] for any maxlength >= 6. I believe the function should have predictable return to avoid errors on the user side.