### PR TITLE
Elastic constants assumed stress error

### DIFF
--- a/tests/test_fit_elastic_constants.py
+++ b/tests/test_fit_elastic_constants.py
@@ -203,6 +203,12 @@ if quippy is not None:
                                              verbose=False, graphics=False)
             self.assertArrayAlmostEqual(C/units.GPa, self.C_ref_relaxed, tol=0.2)
 
+        def testtriclinic_relaxed_assumed_err(self):
+            C, C_err = fit_elastic_constants(self.at0, 'triclinic',
+                                             optimizer=FIRE, fmax=self.fmax,
+                                             verbose=False, graphics=False, stress_err=0.05/self.at0.get_volume())
+            self.assertArrayAlmostEqual(C/units.GPa, self.C_ref_relaxed, tol=0.2)
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Adds an optional analytic BLR mean + error to fit_elastic_constants y=mx+c fit, with assumed priors on the scale of elastic contants (m) and zero strain stresses (c), plus an assumed noise variance on all stress observations (y).

BLR solution is off by default, is turned on when stress_err is not None.