### PR TITLE
Add EU funders to JOSS acknowlegements

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -158,6 +158,6 @@ The module `matscipy.numerical` additionally provides routines for the numerical
 
 # Acknowledgements
 
-We thank Arnaud Allera, Manuel Aldegunde, Kristof Bal, James Brixey, Alexander Held, Jan Jansen, Till Junge, Henry Lambert and Zhilin Zheng for contributions and bug fixes. `matscipy` was partially funded by the Deutsche Forschungsgemeinschaft (projects 258153560, 390951807 and 461911253), the European Research Council (ERC StG 757343), the Engineering and Physical Sciences Research Council (grants EP/P002188/1, EP/R012474/1, EP/R043612/1 and EP/S022848/1) and the Leverhulme Trust (grant RPG-2017-191).
+We thank Arnaud Allera, Manuel Aldegunde, Kristof Bal, James Brixey, Alexander Held, Jan Jansen, Till Junge, Henry Lambert and Zhilin Zheng for contributions and bug fixes. `matscipy` was partially funded by the Deutsche Forschungsgemeinschaft (projects 258153560, 390951807 and 461911253), the European Research Council (ERC StG 757343), the European Commission (NOMAD project grant agreement 951786 and ENTENTE project grant agreement 900018), the Engineering and Physical Sciences Research Council (grants EP/P002188/1, EP/R012474/1, EP/R043612/1 and EP/S022848/1) and the Leverhulme Trust (grant RPG-2017-191).
 
 # References


### PR DESCRIPTION
Add grant references for NOMAD (@jameskermode and others) and ENTENTE (@lakshenoy and @jameskermode ) to JOSS acknowlegements sections.