### PR TITLE
fix: protecting sympy imports in manybody potential tests

### DIFF
--- a/tests/manybody/test_manybody_potentials.py
+++ b/tests/manybody/test_manybody_potentials.py
@@ -5,14 +5,20 @@ import numpy as np
 import numpy.testing as nt
 
 from types import SimpleNamespace
+
 from manybody_fixtures import (
     pair_potential,
     three_body_potential,
     has_sympy,
-    analytical_pair,
-    analytical_triplet,
     FiniteDiff,
 )
+
+if has_sympy:
+    from manybody_fixtures import (
+        analytical_pair,
+        analytical_triplet,
+    )
+
 
 
 def evaluate(pot, *args):


### PR DESCRIPTION
Some sympy-specific imports in manybody tests were not protected if sympy was missing.