### PR TITLE
DOC: fix for ImportError during documentation build

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ jobs:
       - name: install_python
         run: |
           sudo apt-get update -qy
-          sudo apt-get install -y python3-dev python3-pip libxml2-dev libxslt-dev zlib1g-dev
+          sudo apt-get install -y python3-dev python3-pip libxml2-dev libxslt-dev zlib1g-dev libegl1 libopengl-dev
           # Upgrade to latest meson and ninja
           sudo pip install --upgrade meson ninja
 

--- a/docs/applications/plasticity.rst
+++ b/docs/applications/plasticity.rst
@@ -13,7 +13,7 @@ Installation and tests
 The majority of the tests (~70 %) are used during the development and adding new dislocations to the module. The idea is to check if `Dislocation analysis (DXA) <https://www.ovito.org/manual/reference/pipelines/modifiers/dislocation_analysis.html>`_ algorithm detects the same dislocation as we intend to create. These tests require `OVITO python interface <https://www.ovito.org/manual/python/index.html>`_ to be installed and are skipped if it is not detected. If you do not plan to add new structures to the module, you can safely ignore these tests.
 
 Tutorials:
----------
+----------
 
 .. toctree::
 


### PR DESCRIPTION
There were a couple of packages missing that lead to [`ImportError`](https://libatoms.github.io/matscipy/applications/cylinder_configurations.html) during import of ovito for the plasticity documentation. This PR should fix the issue.