### PR TITLE
Cosmetic changes to plasticity docs.

### DIFF
--- a/docs/applications/cylinder_configurations.ipynb
+++ b/docs/applications/cylinder_configurations.ipynb
@@ -63,7 +63,8 @@
     "\n",
     "print(\"Dimensionless burgers vector is: \", BCCMixed111Dislocation.burgers_dimensionless)\n",
     "\n",
-    "print(\"Dislocation core will be at fractional coords \", BCCMixed111Dislocation.unit_cell_core_position_dimensionless, \" within a unit cell\")"
+    "print(\"Dislocation core will be at fractional coords:\\n\", \n",
+    "      BCCMixed111Dislocation.unit_cell_core_position_dimensionless, \" within a unit cell\")"
    ]
   },
   {
@@ -76,16 +77,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BCCScrew111Dislocation\n",
+      "BCCEdge111Dislocation\n",
+      "BCCMixed111Dislocation\n",
+      "BCCEdge100Dislocation\n",
+      "BCCEdge100110Dislocation\n",
+      "DiamondGlide30degreePartial\n",
+      "DiamondGlide90degreePartial\n",
+      "DiamondGlideScrew\n",
+      "DiamondGlide60Degree\n",
+      "FCCScrewShockleyPartial\n",
+      "FCCEdgeShockleyPartial\n",
+      "FCCScrew110Dislocation\n",
+      "FCCEdge110Dislocation\n"
+     ]
+    }
+   ],
    "source": [
     "import matscipy.dislocation as disloc_mod\n",
     "import inspect\n",
-    "# Find all classes in matscipy.dislocation which inherit from the Abstact Base Class CubicCrystalDislocation\n",
+    "# Find all classes in matscipy.dislocation which inherit from \n",
+    "# the Abstract Base Class CubicCrystalDislocation\n",
     "for name, attr in disloc_mod.__dict__.items():\n",
     "    if inspect.isclass(attr):\n",
-    "        if issubclass(attr, disloc_mod.CubicCrystalDislocation) and attr not in [disloc_mod.CubicCrystalDislocation, disloc_mod.CubicCrystalDissociatedDislocation]:\n",
+    "        if issubclass(attr, disloc_mod.CubicCrystalDislocation) and \\\n",
+    "            attr not in [disloc_mod.CubicCrystalDislocation,\n",
+    "                         disloc_mod.CubicCrystalDissociatedDislocation]:\n",
     "            print(name)"
    ]
   },
@@ -965,7 +989,7 @@
     "print(f\"\\nBurgers vector length: {np.linalg.norm(Ni_screw.burgers):.2f} Angstrom\")\n",
     "\n",
     "show_dislocation(Ni_screw_dislo, \n",
-    "                 d_name=\"1/2<110> screw dislocation line\", \n",
+    "                 d_name=\"1/2<110> screw\", \n",
     "                 d_color=[0, 0, 1])"
    ]
   },
@@ -1572,7 +1596,7 @@
     "                 scale=0.3, \n",
     "                 add_bonds=True, \n",
     "                 d_color=[1, 0, 1],\n",
-    "                 partial_distance=5 * Si_screw.glide_distance, \n",
+    "                 partial_distance=5 * Si_60_degree_screw.glide_distance, \n",
     "                 d_name=[\"1/6<112> 90 degree partial screw\", \n",
     "                         \"1/6<112> 30 degree partial screw\"])"
    ]

--- a/docs/applications/multispecies_dislocations.ipynb
+++ b/docs/applications/multispecies_dislocations.ipynb
@@ -102,8 +102,9 @@
     "disloc = DiamondGlide90degreePartial(GaAs, C11, C12, C44)\n",
     "\n",
     "GaAs_bulk, GaAs_dislocation = disloc.build_cylinder(radius=3 * alat)\n",
-    "view = show_dislocation(GaAs_dislocation, scale=0.35, d_name=\"GaAs 1/6<112> Alpha-90 degree partial\", \n",
-    "                 diamond_structure=True, CNA_color=False, add_bonds=True)\n",
+    "view = show_dislocation(GaAs_dislocation, scale=0.35, \n",
+    "                        d_name=\"GaAs 1/6<112> Alpha-90 degree partial\", \n",
+    "                        diamond_structure=True, CNA_color=False, add_bonds=True)\n",
     "\n",
     "view.control.zoom(0.8)\n",
     "view"
@@ -127,8 +128,9 @@
     "disloc = DiamondGlide90degreePartial(GaAs, C11, C12, C44)\n",
     "\n",
     "GaAs_bulk, GaAs_dislocation = disloc.build_cylinder(radius=3 * alat)\n",
-    "view = show_dislocation(GaAs_dislocation, scale=0.35, d_name=\"GaAs 1/6<112> Beta-90 degree partial\", \n",
-    "                 diamond_structure=True, CNA_color=False, add_bonds=True)\n",
+    "view = show_dislocation(GaAs_dislocation, scale=0.35, \n",
+    "                        d_name=\"GaAs 1/6<112> Beta-90 degree partial\", \n",
+    "                        diamond_structure=True, CNA_color=False, add_bonds=True)\n",
     "\n",
     "view.control.zoom(0.8)\n",
     "view"
@@ -176,7 +178,8 @@
     "\n",
     "GaAs_bulk, GaAs_dislocation = disloc.build_cylinder(radius=3 * alat)\n",
     "\n",
-    "show_dislocation(GaAs_dislocation, scale=0.35, d_name=\"GaAs 1/6<112> Beta-90 degree partial\", \n",
+    "show_dislocation(GaAs_dislocation, scale=0.35, \n",
+    "                 d_name=\"GaAs 1/6<112> Beta-90 degree partial\", \n",
     "                 diamond_structure=True, CNA_color=False, add_bonds=True)"
    ]
   },
@@ -213,7 +216,8 @@
     "InGaAs_dislocation = GaAs_dislocation.copy()\n",
     "InGaAs_dislocation.set_chemical_symbols(species)\n",
     "\n",
-    "view = show_dislocation(InGaAs_dislocation, scale=0.35, d_name=\"InGaAs 1/6<112> Beta-90 degree partial\", \n",
+    "view = show_dislocation(InGaAs_dislocation, scale=0.35, \n",
+    "                        d_name=\"InGaAs 1/6<112> Beta-90 degree partial\", \n",
     "                        diamond_structure=True, CNA_color=False, add_bonds=True)\n",
     "\n",
     "# In and Ga have almost the same default colors in nglview\n",
@@ -243,7 +247,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,

--- a/docs/applications/visualisation.py
+++ b/docs/applications/visualisation.py
@@ -138,7 +138,9 @@ def show_dislocation(system, scale=0.5, CNA_color=True, diamond_structure=False,
     view.camera = 'orthographic'
     view.parameters = {"clipDist": 0}
 
-    view._remote_call("setSize", target="Widget", args=["700px", "400px"])
+    #view._remote_call("setSize", target="Widget", args=["400px", "300px"])
+    view.layout.width = '100%'
+    view.layout.height = '300px'
     view.center()
 
     view._js(tooltip_js)
@@ -159,6 +161,8 @@ def interactive_view(system, scale=0.5, name=""):
     view.parameters = {"clipDist": 0}
 
     view.center()
-    view._remote_call("setSize", target="Widget", args=["300px", "300px"])
+    #view._remote_call("setSize", target="Widget", args=["300px", "300px"])
+    view.layout.width = '100%'
+    view.layout.height = '300px'
     view._js(tooltip_js)
     return view


### PR DESCRIPTION
- Changed to `view.layout = '100%'` for automatic resizing with the page width rather than fixed width. Nglview canvas is not resized automatically with page, but is adjusted to the page width when it is refreshed.
- Fixed few typos and cell width to make sure there are no cells larger than maximum width (avoid horizontal scroll bars).