### PR TITLE
BUG: Fix path lims being incorrectly calculated

### DIFF
--- a/matscipy/gamma_surface.py
+++ b/matscipy/gamma_surface.py
@@ -287,14 +287,15 @@ class GammaSurface():
         self.surface_area = np.linalg.norm(np.cross(cell[0, :], cell[1, :]))
         self.surface_separation = np.abs(cell[2, 2])
 
-        dx = self.x_disp / nx
-        dy = self.y_disp / ny
+        dx = self.x_disp
+        dy = self.y_disp
 
 
         self.offsets = []
 
         x_points = np.zeros((nx, 3))
         y_points = np.zeros((ny, 3))
+
 
         for i in range(nx):
             x_points[i, :] = dx * xs[i]

--- a/tests/test_gamma_surface.py
+++ b/tests/test_gamma_surface.py
@@ -23,14 +23,14 @@ class GammaSurfaceTest(matscipytest.MatSciPyTestCase):
         Es = surface.get_energy_densities(self.model)
 
         assert np.min(Es) >= 0.0
-        assert np.allclose(np.max(Es), 0.5311270296466399)
+        assert np.allclose(np.max(Es), 0.3340102322222366)
 
     def test_stacking_fault(self):
         surface = StackingFault(self.at0, np.array([1, 1, 0]), np.array([-1, 1, 0]))
         surface.generate_images(9, z_reps=1, path_ylims=[0, 0.5])
         surface.relax_images(self.model, self.fmax)
         Es = surface.get_energy_densities(self.model)[0, :]
-        assert np.allclose(np.max(Es), 0.020221014385843204)
+        assert np.allclose(np.max(Es), 0.27185793519964985)
 
     def test_disloc_stacking_fault(self):
         from matscipy.dislocation import DiamondGlideScrew


### PR DESCRIPTION
`path_xlims` and `path_ylims` were incorrectly being scaled down. This fixes this bug, stacking faults should now be the correct length.