### PR TITLE
DOC: fixes the interactive visualisations

### DIFF
--- a/docs/applications/cylinder_configurations.ipynb
+++ b/docs/applications/cylinder_configurations.ipynb
@@ -473,7 +473,7 @@
     "Due to stable Intrinsic Stacking Fault (ISF) the 1/2<110> dislocations are not stable and dissociate in two 1/6<112> Shockley partials separated by stacking fault. For example:\n",
     "\n",
     "$$\n",
-    "    \\frac{1}{2}[1\\bar10] \\rightarrow \\frac{1}{6}[2\\bar1\\bar1] + \\mathrm{ISF} + \\frac{1}{2}[1\\bar21]\n",
+    "    \\frac{1}{2}[1\\bar10] \\rightarrow \\frac{1}{6}[2\\bar1\\bar1] + \\mathrm{ISF} + \\frac{1}{6}[1\\bar21]\n",
     "$$\n",
     "\n",
     "where ISF is intrinsic stacking fault. It is possible to pass a parameter `partial_distance` to `build_cylinder()` function in order to create dissociated dislocation. `partial distance` defines separation distance (length of the stacking fault) of two partial dislocations. The value corresponds to number of glide distances the distance in Angstrom be obtaines as `patial_distance * dislocation.glide_distance`."
@@ -724,7 +724,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -284,7 +284,7 @@ texinfo_documents = [
 # Raise Error (not default Warning) when a notebook execution fails
 # (due to code error, timeout, etc.)
 nb_execution_raise_on_error = True
-
+nb_execution_timeout = 60
 
 # -- Extension configuration -------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ ase>=3.16.0
 sphinx_rtd_theme
 jupytext
 sphinxcontrib-spelling
-nglview==3.1.2
+nglview==3.0.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ test = [
 docs = [
     "sphinx",
     "myst_nb",
-    "nglview",
     "numpydoc",
     "atomman",
     "ovito",
@@ -50,7 +49,7 @@ docs = [
     "sphinxcontrib-spelling",
     "pydata-sphinx-theme",
     "jupytext",
-    "nglview==3.1.2"  # resolves https://github.com/libAtoms/matscipy/issues/222
+    "nglview==3.0.8"  # resolves https://github.com/libAtoms/matscipy/issues/222
 ]
 cli = [
     "argcomplete"

--- a/renovate.json
+++ b/renovate.json
@@ -4,3 +4,11 @@
     "config:recommended"
   ]
 }
+{
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["nglview"],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}


### PR DESCRIPTION
Addresses #261 which the same problem as in #222. The fixed version of nglview was [updated by `renovate[bot]`](https://github.com/libAtoms/matscipy/commit/6b429ce28bbe1b4e02b00689314495881ef40fce). I tried to  set an approval for future updates as described in the [documentation](https://docs.renovatebot.com/key-concepts/dashboard/#require-approval-for-specific-packages). I also fixed a couple of typos. 