### PR TITLE
MAINT: Upper bound numpy version <2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.8.0"
 dynamic = ["version"]
 dependencies = [
-    "numpy>=1.16.0",
+    "numpy>=1.16.0, <2.0.0",
     "scipy>=1.2.3",
     "ase>=3.23.0",
     "packaging"


### PR DESCRIPTION
Temporary fix to #267 , capping numpy version in requirements to fix breaking CI tests & docs.

This should be reverted once CI can run successfully with numpy 2.0.