### PR TITLE
Use LGPL in LICENSE.HEADER instead of GPL

### DIFF
--- a/LICENSE.HEADER
+++ b/LICENSE.HEADER
@@ -1,15 +1,16 @@
 matscipy - Materials science with Python at the atomic-scale
 https://github.com/libAtoms/matscipy
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 2 of the License, or
-(at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, see
+<https://www.gnu.org/licenses/>.


### PR DESCRIPTION
I guess this was forgotten when the LICENSE file was properly set to GPL in #69.
I copied the header text from the [official website](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html), it uses "library" instead of "program", I am not sure what is the best definition for this project, but I would guess it is not that important.