### PR TITLE
HCP Stacking faults & Dislocations support

### DIFF
--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -2558,17 +2558,23 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
         
         self.solvers["adsl"] = self.ADstroh.displacement
 
+    @property
+    def _alat(self):
+        # effective lattice constants for each self.axes direction
+        A = np.abs(self.axes)
+        return (A @ self.alat) / np.sum(A, axis=-1)
+
     # @property & @var.setter decorators used to ensure var and var_dimensionless don't get out of sync
     @property
     def burgers(self):
         return self.burgers_dimensionless * self.alat
     
-    @burgers.setter
-    def burgers(self, burgers):
-        self.burgers_dimensionless = burgers / self.alat
+    # @burgers.setter
+    # def burgers(self, burgers):
+    #     self.burgers_dimensionless = burgers / self.alat
 
-    def set_burgers(self, burgers):
-        self.burgers = burgers
+    # def set_burgers(self, burgers):
+    #     self.burgers = burgers
 
     def invert_burgers(self):
         """
@@ -2578,19 +2584,19 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
 
     @property
     def unit_cell_core_position(self):
-        return self.unit_cell_core_position_dimensionless * self.alat
+        return self.unit_cell_core_position_dimensionless * self._alat
     
-    @unit_cell_core_position.setter
-    def unit_cell_core_position(self, position):
-        self.unit_cell_core_position_dimensionless = position / self.alat
+    # @unit_cell_core_position.setter
+    # def unit_cell_core_position(self, position):
+    #     self.unit_cell_core_position_dimensionless = position / self.alat
 
     @property
     def glide_distance(self):
-        return self.glide_distance_dimensionless * self.alat
+        return self.glide_distance_dimensionless * self._alat[0]
     
-    @glide_distance.setter
-    def glide_distance(self, distance):
-        self.glide_distance_dimensionless = distance / self.alat
+    # @glide_distance.setter
+    # def glide_distance(self, distance):
+    #     self.glide_distance_dimensionless = distance / self.alat
 
     def _build_supercell(self, targetx, targety):
         """
@@ -4781,7 +4787,7 @@ class HexagonalDislocation(CubicCrystalDislocation, metaclass=ABCMeta):
         return miller_to_bravais(self.burgers_dimensionless)
     
     @property 
-    def axes(self):
+    def bravais_axes(self):
         return miller_to_bravais(self.axes)
 
 class HCPScrewDislocation(HexagonalDislocation):
@@ -4789,16 +4795,16 @@ class HCPScrewDislocation(HexagonalDislocation):
     # Max Poschmann et al 2018 Modelling Simul. Mater. Sci. Eng. 26 014003
 
     axes = np.array([
-        [0, 0, 1],
         [1, 0, 0],
+        [0, 0, 1],
         [0, 1, 0]
     ])
 
-    burgers_dimensionless = np.array([-1, 2, 0]) * np.sqrt(2)/3
+    burgers_dimensionless = np.array([-1, 2, 0]) / 3
 
-    unit_cell_core_position_dimensionless = np.array([1/4, 3/4, 0])
+    unit_cell_core_position_dimensionless = np.array([1/2, 1/4, 0])
 
-    glide_distance_dimensionless = 1.0
+    glide_distance_dimensionless = 1/2
 
     crystalstructure = "hcp"
 

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -4886,9 +4886,10 @@ class HCPScrewDislocation(HexagonalDissociatedDislocation):
     # https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.117.045301
     # Max Poschmann et al 2018 Modelling Simul. Mater. Sci. Eng. 26 014003
 
-    burgers_dimensionless = np.array([-1, -1, 2, 0]) / 3
+    burgers_dimensionless = np.array([1, 1, -2, 0]) / 3
 
-    new_left_burgers = np.array([-1, 0, 1, 0])/3
+    new_left_burgers = np.array([1, 0, -1, 0]) / 3
+    new_right_burgers = np.array([0, 1, -1, 0]) / 3
     
     left_dislocation = HCP30degreePartial
     right_dislocation = HCP30degreePartial
@@ -4898,9 +4899,10 @@ class HCP60DegreeDislocation(HexagonalDissociatedDislocation):
     # https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.117.045301
     # Max Poschmann et al 2018 Modelling Simul. Mater. Sci. Eng. 26 014003
 
-    burgers_dimensionless = np.array([-2, 1, 1, 0]) / 3
+    burgers_dimensionless = np.array([2, -1, -1, 0]) / 3
 
-    new_left_burgers = np.array([-1, 0, 1, 0]) / 3
+    new_left_burgers = np.array([1, 0, -1, 0]) / 3
+    new_right_burgers = np.array([1, -1, 0, 0]) / 3
     
     left_dislocation = HCP30degreePartial
     right_dislocation = HCP90degreePartial

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -4120,6 +4120,7 @@ class DissociatedDislocation(Dislocation, metaclass=ABCMeta):
 
 class DislocationQuadrupole(DissociatedDislocation):
     burgers_dimensionless = np.zeros(3)
+    burgers = np.zeros(3)
     def __init__(self, disloc_class, *args, **kwargs):
         """
         Initialise dislocation quadrupole class
@@ -4552,7 +4553,7 @@ class DislocationQuadrupole(DissociatedDislocation):
         }
         cutoffs = neigh_dists[self.crystalstructure]
 
-        bulk_coord = [np.min(coordination(bulk, cutoff * self.alat)) for cutoff in cutoffs]
+        bulk_coord = [np.min(coordination(bulk, cutoff * np.average(self.alat))) for cutoff in cutoffs]
 
         full_mask = np.ones((len(tilt_bulk)), dtype=bool)
         atom_heights = np.round(p, precision)[:, 2]
@@ -4562,7 +4563,7 @@ class DislocationQuadrupole(DissociatedDislocation):
             # as normal bulk
             # TODO: This currently does not work for BCCEdge111barDislocation
             if np.prod([
-                all(coordination(tilt_bulk[full_mask], cutoff * self.alat) == bulk_coord[j])
+                all(coordination(tilt_bulk[full_mask], cutoff * np.average(self.alat)) == bulk_coord[j])
                 for j, cutoff in enumerate(cutoffs)
                 ]):
                 return full_mask, cell
@@ -4816,12 +4817,12 @@ class HCP90degreePartial(Dislocation):
     # Journal of Materials Science & Technology. 152. 10.1016/j.jmst.2022.12.029. 
 
     axes = np.array([
-        [1, 0, 0],
+        [-1, 0, 0],
         [0, 0, 1],
         [0, 1, 0]
     ])
 
-    burgers_dimensionless = np.array([-1, 1, 0, 0]) / 3
+    burgers_dimensionless = np.array([1, -1, 0, 0]) / 3
 
     unit_cell_core_position_dimensionless = np.array([1/2, 1/4, 0])
 
@@ -4841,12 +4842,12 @@ class HCP30degreePartial(Dislocation):
     # Journal of Materials Science & Technology. 152. 10.1016/j.jmst.2022.12.029. 
 
     axes = np.array([
-        [1, 0, 0],
+        [-1, 0, 0],
         [0, 0, 1],
         [0, 1, 0]
     ])
 
-    burgers_dimensionless = np.array([0, -1, 1, 0]) / 3
+    burgers_dimensionless = np.array([0, 1, -1, 0]) / 3
 
     unit_cell_core_position_dimensionless = np.array([1/2, 1/4, 0])
 

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -3583,6 +3583,14 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
                 "1/6 1/6 0" : [255, 0, 255], # Pink; Stair Rod
                 "1/3 0 0" : [255, 255, 0], # Yellow; Hirth
                 "1/3 1/3 1/3" : [0, 255, 255] # Cyan; Frank
+            },
+            "hcp" : {
+                "default" : [230, 51, 51], # Red
+                "2/3 1/3 1/3 0" : [0, 255, 0], # Green; Screw, 60 degree
+                "1 0 0 0" : [51, 51, 255], # Blue
+                "1 1 0 0" : [255, 0, 255], # Pink
+                "1/3 1/3 0 0" : [255, 128, 0], # Orange/Brown; 30 & 90 degree partials
+                "1 2/3 1/3 1/3" : [255, 255, 0] # Yellow
             }
         }
 

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -46,7 +46,7 @@ from matscipy.neighbours import neighbour_list, mic, coordination
 from matscipy.elasticity import fit_elastic_constants
 from matscipy.elasticity import Voigt_6x6_to_full_3x3x3x3
 from matscipy.elasticity import cubic_to_Voigt_6x6, coalesce_elastic_constants
-from matscipy.utils import validate_cubic_cell, radial_mask_from_polygon2D, classproperty
+from matscipy.utils import validate_cubic_cell, radial_mask_from_polygon2D, classproperty, bravais_to_miller, miller_to_bravais
 
 
 def make_screw_cyl(alat, C11, C12, C44,
@@ -4774,6 +4774,35 @@ class CubicCrystalDislocationQuadrupole(CubicCrystalDissociatedDislocation):
 # interface to make "Quadrupole" work for both
 Quadrupole = CubicCrystalDislocationQuadrupole
 
+
+class HexagonalDislocation(CubicCrystalDislocation, metaclass=ABCMeta):
+    @property 
+    def bravais_burgers_dimensionless(self):
+        return miller_to_bravais(self.burgers_dimensionless)
+    
+    @property 
+    def axes(self):
+        return miller_to_bravais(self.axes)
+
+class HCPScrewDislocation(HexagonalDislocation):
+    # https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.117.045301
+    # Max Poschmann et al 2018 Modelling Simul. Mater. Sci. Eng. 26 014003
+
+    axes = np.array([
+        [0, 0, 1],
+        [1, 0, 0],
+        [0, 1, 0]
+    ])
+
+    burgers_dimensionless = np.array([-1, 2, 0]) * np.sqrt(2)/3
+
+    unit_cell_core_position_dimensionless = np.array([1/4, 3/4, 0])
+
+    glide_distance_dimensionless = 1.0
+
+    crystalstructure = "hcp"
+
+    name = "HCP Screw"
 
 class BCCScrew111Dislocation(CubicCrystalDislocation):
     crystalstructure = "bcc"

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -4855,7 +4855,7 @@ class HCP90degreePartial(HexagonalDislocation):
 
     crystalstructure = "hcp"
 
-    name = "HCP Screw Partial"
+    name = "1/3<1100> 90 degree partial"
 
     
 class HCP30degreePartial(HexagonalDislocation):
@@ -4880,7 +4880,7 @@ class HCP30degreePartial(HexagonalDislocation):
 
     crystalstructure = "hcp"
 
-    name = "HCP Screw Partial"
+    name = "1/3<0110> 30 degree partial"
 
 class HCPScrewDislocation(HexagonalDissociatedDislocation):
     # https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.117.045301
@@ -4893,7 +4893,7 @@ class HCPScrewDislocation(HexagonalDissociatedDislocation):
     
     left_dislocation = HCP30degreePartial
     right_dislocation = HCP30degreePartial
-    name = "HCP Screw"
+    name = "1/3<1120> Screw"
 
 class HCP60DegreeDislocation(HexagonalDissociatedDislocation):
     # https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.117.045301
@@ -4906,7 +4906,7 @@ class HCP60DegreeDislocation(HexagonalDissociatedDislocation):
     
     left_dislocation = HCP30degreePartial
     right_dislocation = HCP90degreePartial
-    name = "HCP 60degree"
+    name = "1/3<2110> 60 degree"
 
 class BCCScrew111Dislocation(CubicCrystalDislocation):
     crystalstructure = "bcc"

--- a/matscipy/gamma_surface.py
+++ b/matscipy/gamma_surface.py
@@ -286,7 +286,7 @@ class GammaSurface():
         base_struct = self.cut_at * (1, 1, z_reps)
 
         # Atom offset
-        offset = z_offset + self.offset
+        offset = z_offset #+ self.offset
         pos = base_struct.get_positions()
         pos[:, 2] += offset
         base_struct.set_positions(pos)

--- a/matscipy/gamma_surface.py
+++ b/matscipy/gamma_surface.py
@@ -126,7 +126,9 @@ class GammaSurface():
         alat, self.cut_at = validate_cubic_cell(a, axes=ax, 
                                                 crystalstructure=crystalstructure,
                                                 symbol=symbol)
-        self.offset *= alat
+        
+        if alat is not None: # Case when crystalstructure is defined, meaning we have a dislocation passed
+            self.offset *= alat
 
     def _vec_to_miller(self, vec, latex=True, brackets="["):
         '''

--- a/matscipy/utils.py
+++ b/matscipy/utils.py
@@ -2,7 +2,6 @@ import functools
 import warnings
 import numpy as np
 from ase.utils.structure_comparator import SymmetryEquivalenceCheck
-from torch import Value
 
 
 class classproperty:

--- a/matscipy/utils.py
+++ b/matscipy/utils.py
@@ -170,26 +170,26 @@ def validate_cell(a, symbol="w", axes=None, crystalstructure=None, pbc=True):
                                 latticeconstant=alat)
 
             # Check that number of atoms in ats is an integer multiple of ref_ats
-            # (ats has to be the cubic primitive, or a supercell of the cubic primitive)
-            # Also check that the structure is cubic
+            # and that the cells match expectation
             rel_size = len(ats) / len(ref_ats)
+            sup_size = int(rel_size**(1/3))
+            ref_supercell = ref_ats * (sup_size, sup_size, sup_size)
+
             skip_fractional_check = False
             try:
                 # Integer multiple of ats test
                 assert abs(rel_size - np.floor(rel_size)) < tol
 
-                # Cubic cell test: cell = a*I_3x3
-                assert np.allclose(ats.cell[:, :], np.eye(3) * ats.cell[0, 0], atol=tol)
+                # Check cells match closely
+                assert np.allclose(ats.cell[:, :], ref_ats.cell[:, :], atol=tol)
             except AssertionError:
                 # Test failed, skip next test + warn user
                 skip_fractional_check = True
                 
             # Check fractional coords match expectation
             frac_match = True
-            sup_size = int(rel_size**(1/3))
 
             if not skip_fractional_check:
-                ref_supercell = ref_ats * (sup_size, sup_size, sup_size)
 
                 try:
                     apos = np.sort(ats.get_scaled_positions(), axis=0)

--- a/matscipy/utils.py
+++ b/matscipy/utils.py
@@ -282,7 +282,8 @@ def complete_basis(v1, v2=None, normalise=False, nmax=5, tol=1E-6):
 
     if v2 is None:
         V2 = _v2_search(v1, nmax, tol)
-        V2 *= np.sign(V2[0])
+        sgns = [np.sign(x) for x in V2 if x != 0]
+        V2 *= sgns[0] #np.sign(V2[0])
         V2 = V2.astype(int)
     else:
         V2 = np.array(v2).copy().astype(int)

--- a/matscipy/utils.py
+++ b/matscipy/utils.py
@@ -201,6 +201,9 @@ def validate_cell(a, symbol="w", axes=None, crystalstructure=None, pbc=True):
             if not frac_match or skip_fractional_check:
                 warn(f"Input bulk does not appear to match bulk {crystalstructure}.", stacklevel=2)
 
+            if crystalstructure == "hcp":
+                alat = alat[0] # TODO: Fix dislocations for variable c
+
             alat /= sup_size # Account for larger supercells having multiple internal core sites
 
         ats = cut(ats, a=axes_miller[0, :], b=axes_miller[1, :], c=axes_miller[2, :])

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -86,7 +86,7 @@ def cubic_perfect_dislocs():
 def cubic_dissociated_dislocs():
     _cubic_dislocs = cubic_dislocs()
 
-    _cubic_dissociated_dislocs = [item for item in _cubic_dislocs if issubclass(item, sd.Dislocation)]
+    _cubic_dissociated_dislocs = [item for item in _cubic_dislocs if issubclass(item, sd.DissociatedDislocation)]
     
     return _cubic_dissociated_dislocs
 
@@ -683,11 +683,15 @@ class BaseTestDislocation(matscipytest.MatSciPyTestFixture):
 
         self.symbol = test_props[self.structure.lower()]["symbol"]
 
-        self.props = test_props[self.structure.lower()]["props"]
+        self.props = dict(test_props[self.structure.lower()]["props"])
 
         self.default_method = "atomman" if self.has_atomman else "adsl"
 
-        self.cubic = False if self.structure == "HCP" else True
+        self.cubic = False if self.structure.lower() == "hcp" else True
+
+        if not type(self.props["a"]) == list:
+            a = self.props["a"]
+            self.props["a"] = [a, a, a]
 
 
         if issubclass(self.test_cls, sd.DissociatedDislocation):
@@ -744,8 +748,6 @@ class BaseTestDislocation(matscipytest.MatSciPyTestFixture):
         props_dict = dict(self.props) # Create copy of self.props in order to in-place modify
         if gen_bulk:
             props_dict["a"] = ase_bulk(self.symbol, self.structure.lower(), *self.props["a"], cubic=self.cubic)
-        else:
-            props_dict["a"] = self.props["a"]
 
         d = self.test_cls(**props_dict, symbol=self.symbol)
         bulk, disloc = d.build_cylinder(20.0, method=self.default_method, verbose=False)
@@ -932,8 +934,6 @@ class TestCubicCrystalDissociatedDislocation(BaseTestDislocation):
         props_dict = dict(self.props)
         if gen_bulk:
             props_dict["a"] = ase_bulk(self.symbol, self.structure.lower(), *self.props["a"], cubic=self.cubic)
-        else:
-            props_dict = self.props["a"]
 
         d = self.test_cls(**props_dict, symbol=self.symbol)
         
@@ -1119,25 +1119,25 @@ class BaseTestDislocationQuadrupole(matscipytest.MatSciPyTestFixture):
 
 
 
-# @pytest.mark.parametrize("disloc", cubic_perfect_dislocs())
-# class DislocationQuadrupole(BaseTestDislocationQuadrupole):
-#     pass
+@pytest.mark.parametrize("disloc", cubic_perfect_dislocs())
+class DislocationQuadrupole(BaseTestDislocationQuadrupole):
+    pass
 
 
-# @pytest.mark.parametrize("disloc", cubic_dissociated_dislocs())
-# class TestDissociatedDislocationQuadrupole(BaseTestDislocationQuadrupole):
+@pytest.mark.parametrize("disloc", cubic_dissociated_dislocs())
+class TestDissociatedDislocationQuadrupole(BaseTestDislocationQuadrupole):
     
-#     def test_dissociated_quadrupole(self, disloc):
-#         '''
-#         Check execution with no errors
-#         '''
-#         self.set_up_cls(disloc)
+    def test_dissociated_quadrupole(self, disloc):
+        '''
+        Check execution with no errors
+        '''
+        self.set_up_cls(disloc)
 
-#         d = sd.Quadrupole(self.test_cls, **self.props, symbol=self.symbol)
+        d = sd.Quadrupole(self.test_cls, **self.props, symbol=self.symbol)
 
 
-#         # Cell has to be quite big to also have partial distances in there
-#         bulk, quad = d.build_quadrupole(glide_separation=8, partial_distance=2, verbose=False)
+        # Cell has to be quite big to also have partial distances in there
+        bulk, quad = d.build_quadrupole(glide_separation=8, partial_distance=2, verbose=False)
 
 
 


### PR DESCRIPTION
Features:
- Expansion of `matscipy.utils.validate_cell` to support HCP structures as inputs
- Modification of stacking fault + gamma surface tools to support HCP
- Support for dislocations in non-cubic systems (e.g. FCT)
- Implementation of screw and 60deg dislocations + dissociation in HCP
- Tests covering HCP dislocations
- Renaming e.g. `CubicCrystalDislocation` -> `Dislocation`
- Optimisation of disloc quadrupole kink construction (needed for HCP support)

TODO:
- [ ] Visualisation of kink quadrupole structures to check new system works in general
- [ ] Further validation of HCP and FCT dislocations
- [ ] Documentation on FCT & HCP dislocations