### PR TITLE
BUG: Fix plane strain reduction formula for a66 coefficient

### DIFF
--- a/matscipy/fracture_mechanics/crack.py
+++ b/matscipy/fracture_mechanics/crack.py
@@ -106,7 +106,7 @@ class RectilinearAnisotropicCrack:
         self.a12 = b12 - (b13 * b23) / b33
         self.a16 = b16 - (b13 * b36) / b33
         self.a26 = b26 - (b23 * b36) / b33
-        self.a66 = b66
+        self.a66 = b66 - (b36 * b36) / b33
 
         self._init_crack()
 

--- a/tests/test_rectilinear_anisotropic_crack.py
+++ b/tests/test_rectilinear_anisotropic_crack.py
@@ -1,0 +1,121 @@
+#
+# Copyright 2025 Lars Pastewka (U. Freiburg)
+#           2025 James Kermode (Warwick U.)
+#
+# matscipy - Materials science with Python at the atomic-scale
+# https://github.com/libAtoms/matscipy
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import unittest
+import numpy as np
+
+from matscipy.fracture_mechanics.crack import RectilinearAnisotropicCrack
+
+
+class TestRectilinearAnisotropicCrack(unittest.TestCase):
+    """Test the RectilinearAnisotropicCrack class."""
+
+    def test_plane_strain_reduction_formula(self):
+        """
+        Test that the plane strain reduction formula is applied consistently
+        to all elastic constants.
+
+        The plane strain reduction from 3D compliance matrix (b_ij) to
+        2D compliance matrix (a_ij) follows the formula:
+            a_ij = b_ij - (b_i3 * b_j3) / b33
+
+        This test verifies that all components, including a66, follow this
+        pattern. See Andric & Curtin (2019), Eq. 21:
+        P Andric and W A Curtin 2019 Modelling Simul. Mater. Sci. Eng. 27 013001
+        https://iopscience.iop.org/article/10.1088/1361-651X/aae40c/meta
+
+        Related to GitHub issue #275.
+        """
+        crack = RectilinearAnisotropicCrack()
+
+        # Use arbitrary compliance values where b36 != 0
+        # These don't need to represent a physical material, just test the formula
+        b11, b22, b33 = 1.0, 2.0, 3.0
+        b12, b13, b23 = 0.5, 0.3, 0.4
+        b16, b26, b36 = 0.2, 0.25, 0.35  # Non-zero b36 is critical for this test
+        b66 = 1.5
+
+        crack.set_plane_strain(b11, b22, b33, b12, b13, b23,
+                               b16, b26, b36, b66)
+
+        # Verify the reduction formula is applied consistently to all components
+        np.testing.assert_allclose(crack.a11, b11 - (b13 * b13) / b33,
+                                   err_msg="a11 reduction formula incorrect")
+        np.testing.assert_allclose(crack.a22, b22 - (b23 * b23) / b33,
+                                   err_msg="a22 reduction formula incorrect")
+        np.testing.assert_allclose(crack.a12, b12 - (b13 * b23) / b33,
+                                   err_msg="a12 reduction formula incorrect")
+        np.testing.assert_allclose(crack.a16, b16 - (b13 * b36) / b33,
+                                   err_msg="a16 reduction formula incorrect")
+        np.testing.assert_allclose(crack.a26, b26 - (b23 * b36) / b33,
+                                   err_msg="a26 reduction formula incorrect")
+
+        # This is the critical test - a66 should also follow the pattern
+        # Following the pattern: a66 = b66 - (b36 * b36) / b33
+        # (Note: b63 = b36 due to matrix symmetry)
+        np.testing.assert_allclose(crack.a66, b66 - (b36 * b36) / b33,
+                                   err_msg="a66 reduction formula incorrect - should be b66 - (b36*b36)/b33")
+
+    def test_plane_strain_zero_coupling(self):
+        """
+        Test plane strain reduction when b36 = 0 (no coupling).
+
+        When b36 = 0, the a66 = b66 - (b36*b36)/b33 simplifies to a66 = b66,
+        so both the buggy and correct implementations give the same result.
+        This test ensures we don't break this special case.
+        """
+        crack = RectilinearAnisotropicCrack()
+
+        b11, b22, b33 = 1.0, 2.0, 3.0
+        b12, b13, b23 = 0.5, 0.3, 0.4
+        b16, b26, b36 = 0.2, 0.25, 0.0  # b36 = 0
+        b66 = 1.5
+
+        crack.set_plane_strain(b11, b22, b33, b12, b13, b23,
+                               b16, b26, b36, b66)
+
+        # When b36 = 0, a66 should equal b66
+        np.testing.assert_allclose(crack.a66, b66)
+
+    def test_plane_stress_unchanged(self):
+        """
+        Test that plane stress formula remains unchanged.
+
+        Plane stress directly uses the compliance components without reduction.
+        """
+        crack = RectilinearAnisotropicCrack()
+
+        a11, a22, a12 = 1.0, 2.0, 0.5
+        a16, a26, a66 = 0.2, 0.25, 1.5
+
+        crack.set_plane_stress(a11, a22, a12, a16, a26, a66)
+
+        # Plane stress should directly assign values
+        np.testing.assert_allclose(crack.a11, a11)
+        np.testing.assert_allclose(crack.a22, a22)
+        np.testing.assert_allclose(crack.a12, a12)
+        np.testing.assert_allclose(crack.a16, a16)
+        np.testing.assert_allclose(crack.a26, a26)
+        np.testing.assert_allclose(crack.a66, a66)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the plane strain reduction formula for the `a66` coefficient in `RectilinearAnisotropicCrack`. The bug caused incorrect crack calculations when materials had non-zero coupling between shear and out-of-plane directions (`b36 ≠ 0`).

## Problem

In the `set_plane_strain` method, all elastic constants were correctly transformed from 3D to 2D using the formula:

```
a_ij = b_ij - (b_i3 * b_j3) / b33
```

**except** for `a66`, which was simply set to `b66` without the correction term.

## Solution

Changed line 109 in `matscipy/fracture_mechanics/crack.py` from:
```python
self.a66 = b66
```
to:
```python
self.a66 = b66 - (b36 * b36) / b33
```

This makes `a66` consistent with all other coefficients.

## Testing

Added comprehensive unit tests in `tests/test_rectilinear_anisotropic_crack.py` that:
1. Verify the reduction formula is applied consistently to all components
2. Test the special case when `b36 = 0` (where both formulas give the same result)
3. Verify plane stress behavior remains unchanged

The test **fails** before the fix and **passes** after, confirming the bug and the solution.

## Impact

This bug affected:
- Crack tip displacement fields
- Crack tip stress fields  
- Stress intensity factor calculations

for anisotropic materials in plane strain with non-zero `b36` coupling.

## References

- Fixes #275 
- Reported by @Wang-Chen-Warwick
- Literature: P Andric and W A Curtin (2019) *Modelling Simul. Mater. Sci. Eng.* **27** 013001, Equation 21
  https://iopscience.iop.org/article/10.1088/1361-651X/aae40c/meta

🤖 Generated with [Claude Code](https://claude.com/claude-code)