### PR TITLE
BUG: Fix fit_elastic_constants KeyError with symmetry='hexagonal'

### DIFF
--- a/matscipy/elasticity.py
+++ b/matscipy/elasticity.py
@@ -1211,7 +1211,7 @@ def fit_elastic_constants(
     for k, v in Cij_err.items():
         Cij_err[k] = np.sqrt(np.sum(np.array(v) ** 2)) / np.sqrt(len(v))
 
-    if symmetry.startswith("trigonal"):
+    if symmetry.startswith("trigonal") or symmetry == "hexagonal":
         # Special case for trigonal lattice: C66 = (C11 - C12)/2
         Cijs[Cij_map[(5, 5)]] = 0.5 * (Cijs[Cij_map[(0, 0)]] - Cijs[Cij_map[(0, 1)]])
         Cij_err[Cij_map[(5, 5)]] = np.sqrt(

--- a/tests/test_fit_elastic_constants.py
+++ b/tests/test_fit_elastic_constants.py
@@ -209,6 +209,45 @@ if quippy is not None:
                                              verbose=False, graphics=False, stress_err=0.05/self.at0.get_volume())
             self.assertArrayAlmostEqual(C/units.GPa, self.C_ref_relaxed, tol=0.2)
 
+class TestHexagonalElasticConstants(unittest.TestCase):
+    """Test that fit_elastic_constants works with symmetry='hexagonal' (#306)."""
+
+    def test_hexagonal_does_not_raise(self):
+        """fit_elastic_constants with symmetry='hexagonal' should not KeyError."""
+        from ase.build import bulk
+        from ase.calculators.lj import LennardJones
+
+        atoms = bulk('Ti', 'hcp', a=2.95, c=4.68)
+        atoms.calc = LennardJones()
+        C, C_err = fit_elastic_constants(atoms, symmetry='hexagonal',
+                                         verbose=False)
+
+    def test_hexagonal_c66_relation(self):
+        """C66 should equal (C11 - C12) / 2 for hexagonal symmetry."""
+        from ase.build import bulk
+        from ase.calculators.lj import LennardJones
+
+        atoms = bulk('Ti', 'hcp', a=2.95, c=4.68)
+        atoms.calc = LennardJones()
+        C, C_err = fit_elastic_constants(atoms, symmetry='hexagonal',
+                                         verbose=False)
+        np.testing.assert_allclose(C[5, 5], 0.5 * (C[0, 0] - C[0, 1]),
+                                   rtol=1e-10)
+
+    def test_hexagonal_matches_trigonal_high(self):
+        """hexagonal and trigonal_high should give identical results."""
+        from ase.build import bulk
+        from ase.calculators.lj import LennardJones
+
+        atoms = bulk('Ti', 'hcp', a=2.95, c=4.68)
+        atoms.calc = LennardJones()
+        C_hex, _ = fit_elastic_constants(atoms, symmetry='hexagonal',
+                                         verbose=False)
+        C_trig, _ = fit_elastic_constants(atoms, symmetry='trigonal_high',
+                                          verbose=False)
+        np.testing.assert_allclose(C_hex, C_trig, rtol=1e-10)
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
## Summary
- Fixes `KeyError: 6` when calling `fit_elastic_constants(atoms, symmetry='hexagonal')` by extending the C66 = (C11 - C12)/2 special-case check to also match `"hexagonal"` (not just symmetries starting with `"trigonal"`)
- Adds tests verifying no KeyError, correct C66 relation, and identical results to `trigonal_high`

Fixes #306

## Test plan
- [x] `test_hexagonal_does_not_raise` — no KeyError with `symmetry='hexagonal'`
- [x] `test_hexagonal_c66_relation` — C66 == (C11 - C12) / 2
- [x] `test_hexagonal_matches_trigonal_high` — identical to `trigonal_high` results

🤖 Generated with [Claude Code](https://claude.com/claude-code)