### PR TITLE
BUG/CI: Fix docs build TypeError and update cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -3621,7 +3621,7 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
 
             # Use burgers vector to get a key for the dislocation line colour
             # Sorting and abs remove the rotational dependance, reducing the number of possible keys
-            colour_key = " ".join([str(Fraction(elem).limit_denominator(10)) for elem in b_sorted])
+            colour_key = " ".join([str(Fraction(float(elem)).limit_denominator(10)) for elem in b_sorted])
 
             if color is None:
                 if colour_key in disloc_colours[self.crystalstructure.lower()]:
@@ -3633,7 +3633,7 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
                 colour = color[idx]
 
             if disloc_names is None:
-                seg_name = f"b=[" + " ".join([str(Fraction(elem).limit_denominator(10)) for elem in b]) + "]"
+                seg_name = f"b=[" + " ".join([str(Fraction(float(elem)).limit_denominator(10)) for elem in b]) + "]"
             else:
                 seg_name = disloc_names[idx]
 


### PR DESCRIPTION
## Summary
- Fix `TypeError` in `dislocation.py:_plot_DXA_disloc_line()` where `Fraction(numpy_float)` fails on Python 3.12+ because numpy scalars are no longer `Rational` instances. Wraps in `float()` before passing to `Fraction()`.
- Update `cibuildwheel` from `v3.3.0` to `v3.4.0` because the Docker images referenced by v3.3.0 (`musllinux_1_2_x86_64:2025.11.09-2`) have been removed from quay.io, causing ubuntu wheel builds to fail.

Both issues appeared since the last master CI run (Jan 6, 2026) due to upstream dependency/infrastructure changes.

## Test plan
- [ ] Documentation workflow: `cylinder_configurations.ipynb` executes without TypeError
- [ ] Build wheels workflow: `cp311 on ubuntu-22.04` succeeds
- [ ] All other CI jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)