### PR TITLE
BUG: Fix Fraction(numpy_float) TypeError and update cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -3621,7 +3621,7 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
 
             # Use burgers vector to get a key for the dislocation line colour
             # Sorting and abs remove the rotational dependance, reducing the number of possible keys
-            colour_key = " ".join([str(Fraction(elem).limit_denominator(10)) for elem in b_sorted])
+            colour_key = " ".join([str(Fraction(float(elem)).limit_denominator(10)) for elem in b_sorted])
 
             if color is None:
                 if colour_key in disloc_colours[self.crystalstructure.lower()]:
@@ -3633,7 +3633,7 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
                 colour = color[idx]
 
             if disloc_names is None:
-                seg_name = f"b=[" + " ".join([str(Fraction(elem).limit_denominator(10)) for elem in b]) + "]"
+                seg_name = f"b=[" + " ".join([str(Fraction(float(elem)).limit_denominator(10)) for elem in b]) + "]"
             else:
                 seg_name = disloc_names[idx]
 


### PR DESCRIPTION
## Summary

- **Docs build fix:** Convert numpy scalars to Python `float` before passing to `fractions.Fraction()` in `_plot_DXA_disloc_line()` (dislocation.py lines 3624, 3636). In numpy 2.x, numpy scalars are no longer `Rational` instances, causing `TypeError` when executing `cylinder_configurations.ipynb` during the docs build.
- **Wheel build fix:** Update `cibuildwheel` from `v3.3.0` to `v3.4.0` to resolve missing Docker image `quay.io/pypa/musllinux_1_2_x86_64:2025.11.09-2` that was causing ubuntu wheel builds to fail.

Both failures are pre-existing on master (not caused by any recent PR) and will block all CI until fixed.

## Test plan

- [ ] Docs build CI job passes (no TypeError in `cylinder_configurations.ipynb`)
- [ ] Wheel build jobs pass on ubuntu (Docker images resolve correctly)
- [ ] All other CI jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)