### PR TITLE
Feat/2605 dpd

### DIFF
--- a/matscipy/dpd.py
+++ b/matscipy/dpd.py
@@ -1,0 +1,126 @@
+
+
+"""
+Peters DPD thermostat.
+
+Reference:
+    E. A. J. F. Peters, Europhys. Lett. 66, 311 (2004).
+"""
+
+import numpy as np
+from ase.md.verlet import VelocityVerlet
+from ase.neighborlist import NeighborList
+from ase.units import kB
+
+
+class DPDThermostat(VelocityVerlet):
+    """Peters DPD thermostat with time-step-independent equilibrium statistics.
+
+    Combines velocity Verlet integration for conservative forces with the
+    pairwise momentum re-equilibration scheme (Scheme II) of Peters (2004).
+    The thermostat leaves the Maxwell-Boltzmann distribution invariant for any
+    finite time step; residual time-step error comes solely from the
+    discretisation of the conservative (Verlet) part.
+
+    After each Verlet step all pairs within *cutoff* are processed
+    simultaneously in a vectorised manner. Note that this deviates
+    from the approach in Peters, where each pair is updated
+    sequentially in a randomized manner
+
+    Parameters
+    ----------
+    atoms : ase.Atoms
+        The Atoms object to operate on.
+    timestep : float
+        Time step in ASE time units.  Use ``ase.units.fs`` to convert from fs.
+    T : float
+        Target temperature in Kelvin.
+    gamma : float
+        Friction coefficient in ASE units (amu / ASE_time_unit).
+    cutoff : float
+        Pairwise interaction cutoff radius in Angstrom used for the neighbor list.
+    weight_function : callable, optional
+        ``omega(r)`` — weight function of pair distance *r* (array in).
+        Defaults to ``max(1 - r / cutoff, 0) ** 2`` as in the original DPD
+        formulation (eq. 2 of Peters 2004).
+    **kwargs
+        Extra arguments forwarded to :class:`ase.md.md.MolecularDynamics`
+        (e.g. ``trajectory``, ``logfile``, ``loginterval``).
+    """
+
+    def __init__(self, atoms, timestep, T, gamma, cutoff,
+                 weight_function=None, **kwargs):
+        super().__init__(atoms, timestep, **kwargs)
+        self.T = T
+        self.gamma = gamma
+        self.cutoff = cutoff
+        self.kT = T * kB
+
+        if weight_function is None:
+            self._weight = lambda r: np.maximum(1.0 - r / cutoff, 0.0) ** 2
+        else:
+            self._weight = weight_function
+
+        self._nl = NeighborList(
+            [cutoff / 2] * len(atoms),
+            skin=0.0,
+            self_interaction=False,
+            bothways=False,
+        )
+
+    def step(self, forces=None):
+        forces = super().step(forces)
+        self._apply_thermostat()
+        return forces
+
+    def _apply_thermostat(self):
+        """Apply one simultaneous pairwise thermostat step (Scheme II)."""
+        atoms = self.atoms
+        positions = atoms.get_positions()
+        momenta = atoms.get_momenta()
+        masses = atoms.get_masses()
+        cell = atoms.get_cell()
+
+        self._nl.update(atoms)
+
+        i_list, j_list, dr_list = [], [], []
+        for i in range(len(atoms)):
+            indices, offsets = self._nl.get_neighbors(i)
+            for j, offset in zip(indices, offsets):
+                i_list.append(i)
+                j_list.append(j)
+                dr_list.append(positions[j] + offset @ cell - positions[i])
+
+        if not i_list:
+            return
+
+        i_arr = np.array(i_list)
+        j_arr = np.array(j_list)
+        dr = np.array(dr_list)           # (N_pairs, 3)
+
+        r = np.linalg.norm(dr, axis=1)  # (N_pairs,)
+        r_hat = dr / r[:, None]
+
+        mi = masses[i_arr]
+        mj = masses[j_arr]
+        mu = mi * mj / (mi + mj)        # reduced mass
+
+        # Scheme II (Table I of Peters 2004): exact integration of the
+        # irreversible pair dynamics over one time step dt.
+        W = self.gamma * self._weight(r) * self.dt / mu  # dimensionless
+        a_dt = mu * (1.0 - np.exp(-W))
+        b_sqdt = np.sqrt(self.kT * mu * (1.0 - np.exp(-2.0 * W)))
+
+        vi = momenta[i_arr] / mi[:, None]
+        vj = momenta[j_arr] / mj[:, None]
+        v_proj = np.einsum('ij,ij->i', vi - vj, r_hat)  # (v_i - v_j) . r_hat
+
+        xi = np.random.normal(size=len(i_arr))
+        dp_mag = -a_dt * v_proj + b_sqdt * xi
+        dp = dp_mag[:, None] * r_hat    # (N_pairs, 3)
+
+        # Simultaneous update: accumulate all momentum changes, then apply.
+        np.add.at(momenta, i_arr, dp)
+        np.add.at(momenta, j_arr, -dp)
+
+        atoms.set_momenta(momenta, apply_constraint=False)

--- a/matscipy/dpd.py
+++ b/matscipy/dpd.py
@@ -43,14 +43,18 @@ class DPDThermostat(VelocityVerlet):
         ``omega(r)`` — weight function of pair distance *r* (array in).
         Defaults to ``max(1 - r / cutoff, 0) ** 2`` as in the original DPD
         formulation (eq. 2 of Peters 2004).
+    rng : numpy.random.Generator, optional
+        Random number generator.  Pass ``numpy.random.default_rng(seed)``
+        for reproducible runs.  Defaults to a fresh (non-seeded) generator.
     **kwargs
         Extra arguments forwarded to :class:`ase.md.md.MolecularDynamics`
         (e.g. ``trajectory``, ``logfile``, ``loginterval``).
     """
 
     def __init__(self, atoms, timestep, T, gamma, cutoff,
-                 weight_function=None, **kwargs):
+                 weight_function=None, rng=None, **kwargs):
         super().__init__(atoms, timestep, **kwargs)
+        self.rng = np.random.default_rng() if rng is None else rng
         self.T = T
         self.gamma = gamma
         self.cutoff = cutoff
@@ -115,7 +119,7 @@ class DPDThermostat(VelocityVerlet):
         vj = momenta[j_arr] / mj[:, None]
         v_proj = np.einsum('ij,ij->i', vi - vj, r_hat)  # (v_i - v_j) . r_hat
 
-        xi = np.random.normal(size=len(i_arr))
+        xi = self.rng.standard_normal(size=len(i_arr))
         dp_mag = -a_dt * v_proj + b_sqdt * xi
         dp = dp_mag[:, None] * r_hat    # (N_pairs, 3)
 

--- a/matscipy/dpd.py
+++ b/matscipy/dpd.py
@@ -10,6 +10,7 @@ Reference:
 import numpy as np
 from ase.md.verlet import VelocityVerlet
 from ase.neighborlist import NeighborList
+from ase.neighborlist import neighbor_list as ase_neighbor_list
 from ase.units import kB
 
 
@@ -52,7 +53,7 @@ class DPDThermostat(VelocityVerlet):
     """
 
     def __init__(self, atoms, timestep, T, gamma, cutoff,
-                 weight_function=None, rng=None, **kwargs):
+                 weight_function=None, rng=None, neighbor_list=ase_neighbor_list , **kwargs):
         super().__init__(atoms, timestep, **kwargs)
         self.rng = np.random.default_rng() if rng is None else rng
         self.T = T
@@ -65,12 +66,7 @@ class DPDThermostat(VelocityVerlet):
         else:
             self._weight = weight_function
 
-        self._nl = NeighborList(
-            [cutoff / 2] * len(atoms),
-            skin=0.0,
-            self_interaction=False,
-            bothways=False,
-        )
+        self._nl = neighbor_list
 
     def step(self, forces=None):
         forces = super().step(forces)
@@ -85,46 +81,53 @@ class DPDThermostat(VelocityVerlet):
         masses = atoms.get_masses()
         cell = atoms.get_cell()
 
-        self._nl.update(atoms)
+        i, j, dist, dr = self._nl('ijdD', atoms, cutoff=self.cutoff / 2)
 
-        i_list, j_list, dr_list = [], [], []
-        for i in range(len(atoms)):
-            indices, offsets = self._nl.get_neighbors(i)
-            for j, offset in zip(indices, offsets):
-                i_list.append(i)
-                j_list.append(j)
-                dr_list.append(positions[j] + offset @ cell - positions[i])
+        # Avoid double counting of pairs
+        mask = j < i
+        i = i[mask]
+        j = j[mask]
+        dist = dist[mask]
+        dr = dr[mask]
 
-        if not i_list:
-            return
+        # i_list, j_list, dr_list = [], [], []
+        # for i in range(len(atoms)):
+        #     indices, offsets = self._nl.get_neighbors(i)
+        #     for j, offset in zip(indices, offsets):
+        #         i_list.append(i)
+        #         j_list.append(j)
+        #         dr_list.append(positions[j] + offset @ cell - positions[i])
+        #
+        # if not i_list:
+        #     return
+        #
+        # i_arr = np.array(i_list)
+        # j_arr = np.array(j_list)
+        # dr = np.array(dr_list)           # (N_pairs, 3)
+        #
+        # r = np.linalg.norm(dr, axis=1)  # (N_pairs,)
+        r_hat = dr / dist[:, None]
 
-        i_arr = np.array(i_list)
-        j_arr = np.array(j_list)
-        dr = np.array(dr_list)           # (N_pairs, 3)
-
-        r = np.linalg.norm(dr, axis=1)  # (N_pairs,)
-        r_hat = dr / r[:, None]
-
-        mi = masses[i_arr]
-        mj = masses[j_arr]
+        mi = masses[i]
+        mj = masses[j]
         mu = mi * mj / (mi + mj)        # reduced mass
 
         # Scheme II (Table I of Peters 2004): exact integration of the
         # irreversible pair dynamics over one time step dt.
-        W = self.gamma * self._weight(r) * self.dt / mu  # dimensionless
+        W = self.gamma * self._weight(dist) * self.dt / mu  # dimensionless
         a_dt = mu * (1.0 - np.exp(-W))
         b_sqdt = np.sqrt(self.kT * mu * (1.0 - np.exp(-2.0 * W)))
 
-        vi = momenta[i_arr] / mi[:, None]
-        vj = momenta[j_arr] / mj[:, None]
+        vi = momenta[i] / mi[:, None]
+        vj = momenta[j] / mj[:, None]
         v_proj = np.einsum('ij,ij->i', vi - vj, r_hat)  # (v_i - v_j) . r_hat
 
-        xi = self.rng.standard_normal(size=len(i_arr))
+        xi = self.rng.standard_normal(size=len(i))
         dp_mag = -a_dt * v_proj + b_sqdt * xi
         dp = dp_mag[:, None] * r_hat    # (N_pairs, 3)
 
         # Simultaneous update: accumulate all momentum changes, then apply.
-        np.add.at(momenta, i_arr, dp)
-        np.add.at(momenta, j_arr, -dp)
+        np.add.at(momenta, i, dp)
+        np.add.at(momenta, j, -dp)
 
         atoms.set_momenta(momenta, apply_constraint=False)

--- a/matscipy/dpd.py
+++ b/matscipy/dpd.py
@@ -81,7 +81,7 @@ class DPDThermostat(VelocityVerlet):
         masses = atoms.get_masses()
         cell = atoms.get_cell()
 
-        i, j, dist, dr = self._nl('ijdD', atoms, cutoff=self.cutoff / 2)
+        i, j, dist, dr = self._nl('ijdD', atoms, cutoff=self.cutoff)
 
         # Avoid double counting of pairs
         mask = j < i

--- a/matscipy/meson.build
+++ b/matscipy/meson.build
@@ -38,7 +38,8 @@ python_sources = [
     'visualise.py',
     'cauchy_born.py',
     'surface_reconstruction.py',
-    'utils.py'
+    'utils.py',
+    'dpd.py'
 ]
 
 # Install pure Python

--- a/matscipy/molecules.py
+++ b/matscipy/molecules.py
@@ -72,19 +72,19 @@ class Molecules:
             self.__dict__[data] = np.array([], dtype=dtype)
 
         if bonds_connectivity is not None:
-            self.bonds.resize(len(bonds_connectivity))
+            self.bonds = np.empty(len(bonds_connectivity), dtype=self._dtypes["bonds"])
             self.bonds["atoms"][:] = bonds_connectivity
             self.bonds["type"][:] = bonds_types \
                 if bonds_types is not None else default_type
 
         if angles_connectivity is not None:
-            self.angles.resize(len(angles_connectivity))
+            self.angles = np.empty(len(angles_connectivity), dtype=self._dtypes["angles"])
             self.angles["atoms"][:] = angles_connectivity
             self.angles["type"][:] = angles_types \
                 if angles_types is not None else default_type
 
         if dihedrals_connectivity is not None:
-            self.dihedrals.resize(len(dihedrals_connectivity))
+            self.dihedrals = np.empty(len(dihedrals_connectivity), dtype=self._dtypes["dihedrals"])
             self.dihedrals["atoms"][:] = dihedrals_connectivity
             self.dihedrals["type"][:] = dihedrals_types \
                 if dihedrals_types is not None else default_type

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [aliases]
 test = pytest
 
-[pytest]
+[tool:pytest]
 addopts = --verbose --rootdir=tests
 
 [yapf]

--- a/temp_resources/test_dpd_temperature.ipynb
+++ b/temp_resources/test_dpd_temperature.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    ""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_dpd.py
+++ b/tests/test_dpd.py
@@ -51,7 +51,7 @@ class TestDPDThermostat:
     def test_temperature_convergence(self):
         """Kinetic temperature must converge to T_target within 5%."""
         atoms = _make_gas(n=200)
-        dyn = DPDThermostat(atoms, **_COMMON)
+        dyn = DPDThermostat(atoms, **_COMMON, rng=np.random.default_rng(0))
 
         for _ in range(200):   # equilibration
             dyn.step()
@@ -74,7 +74,7 @@ class TestDPDThermostat:
         atoms.set_momenta(rng.normal(size=(50, 3)))
         p0 = atoms.get_momenta().sum(axis=0).copy()
 
-        dyn = DPDThermostat(atoms, **_COMMON)
+        dyn = DPDThermostat(atoms, **_COMMON, rng=np.random.default_rng(1))
         for _ in range(100):
             dyn.step()
             p = atoms.get_momenta().sum(axis=0)
@@ -87,7 +87,7 @@ class TestDPDThermostat:
         symbols = ['Ar'] * (n // 2) + ['Ne'] * (n // 2)
         atoms = _make_gas(n=n, symbols=symbols, seed=7)
 
-        dyn = DPDThermostat(atoms, **_COMMON)
+        dyn = DPDThermostat(atoms, **_COMMON, rng=np.random.default_rng(3))
         for _ in range(500):   # longer equilibration: unequal masses need more steps
             dyn.step()
 

--- a/tests/test_dpd.py
+++ b/tests/test_dpd.py
@@ -110,7 +110,7 @@ class TestDPDThermostat:
         n_equil = max(1, round(t_equil / dt))
         n_sample = max(1, round(t_sample / dt))
 
-        atoms = _make_noninteracting_gas(n=200, density=4, initialize_velocities=False)
+        atoms = _make_noninteracting_gas(n=100, density=4, initialize_velocities=False)
         dyn = DPDThermostat(atoms, dt,
                             rng = np.random.default_rng(seed),
                             **self.THERMOSTAT_PARAMETERS
@@ -162,7 +162,7 @@ class TestDPDThermostat:
     @pytest.mark.parametrize("seed", [0, 1,])
     def test_temperature_convergence_unequal_masses(self, seed):
         """Temperature must converge with a mixture of two species."""
-        n = 200
+        n = 100
         symbols = ['Ar'] * (n // 2) + ['Ne'] * (n // 2)
         atoms = _make_noninteracting_gas(n=n, density=4,
                                          masses =[1.] * (n // 2) + [4.] * (n // 2),
@@ -242,7 +242,7 @@ def test_repulsive_gas(seed):
     """
 
     REP_AMPLITUDE = 25.0  # repulsive force amplitude
-    N_ATOMS = 500
+    N_ATOMS = 100
     BOX = (N_ATOMS / 4) ** (1 / 3)  # keeps density = 4
 
 

--- a/tests/test_dpd.py
+++ b/tests/test_dpd.py
@@ -11,6 +11,7 @@ import os
 
 from matscipy.dpd import DPDThermostat
 from matscipy.neighbours import neighbour_list as matscipy_neighbor_list
+from ase.neighborlist import neighbor_list as ase_neighbor_list
 
 
 class ZeroForceCalculator(Calculator):
@@ -57,7 +58,6 @@ def _make_noninteracting_gas(n=200, density=4,  seed=42, initialize_velocities=T
     else:
         atoms.set_momenta(np.zeros((n, 3)))
 
-
     return atoms
 
 
@@ -67,6 +67,28 @@ def _kinetic_kBT(atoms):
     m = atoms.get_masses()
     ekin = 0.5 * np.sum(p ** 2 / m[:, None])
     return 2 * ekin / (3 * len(atoms))
+
+
+@pytest.mark.parametrize("neighbor_list", [matscipy_neighbor_list, ase_neighbor_list])
+def test_neighbors_cutoff(neighbor_list):
+    """
+
+    Asserts the cutoff passed to neighbor list functions represents the distance between the atoms.
+
+    """
+
+    atoms = Atoms(['H', 'H'], positions=[[0,0,0], [0,0,1]], pbc=False, cell=[2,2,2])
+
+    i,j,d = neighbor_list('ijd', atoms, cutoff=1.01)
+    assert len(i) == 2
+    assert len(j) == 2
+    assert len(d) == 2
+
+
+    i,j,d = neighbor_list('ijd', atoms, cutoff=0.6)
+    assert len(i) == 0
+    assert len(j) == 0
+    assert len(d) == 0
 
 
 class TestDPDThermostat:
@@ -82,8 +104,8 @@ class TestDPDThermostat:
         """Kinetic temperature must converge to T_target within 5%."""
 
         dt = 0.05
-        t_equil = 3.
-        t_sample = 7.
+        t_equil = 5.
+        t_sample = 20.
 
         n_equil = max(1, round(t_equil / dt))
         n_sample = max(1, round(t_sample / dt))
@@ -146,7 +168,6 @@ class TestDPDThermostat:
                                          masses =[1.] * (n // 2) + [4.] * (n // 2),
                                          seed=seed)
 
-
         dt = 0.05
 
         t_equil = 3.
@@ -172,3 +193,110 @@ class TestDPDThermostat:
             f"Temperature {kBT_mean:.4f} 1 deviates more than 5% from "
             f"target 1 "
         )
+
+
+
+
+# --- Conservative force calculator -------------------------------------------
+
+class DPDRepulsiveCalculator(Calculator):
+    """Pairwise repulsive force F_ij = a*(1-r/rc)*r_hat_ij.
+
+    matscipy.neighbour_list returns both (i,j) and (j,i), so forces are
+    accumulated only on i.
+    """
+    implemented_properties = ['energy', 'forces']
+
+    def __init__(self, a=25., rc=RC):
+        super().__init__()
+        self.a = a
+        self.rc = rc
+
+    def calculate(self, atoms=None, properties=None, system_changes=all_changes):
+        Calculator.calculate(self, atoms, properties, system_changes)
+        n = len(atoms)
+        forces = np.zeros((n, 3))
+        energy = 0.0
+
+        i, j, D, d = matscipy_neighbor_list('ijDd', atoms, cutoff=self.rc)
+
+        if len(i) > 0:
+            w = 1.0 - d / self.rc                        # (1-r/rc), shape (P,)
+            # D = r_j - r_i; repulsive force on i points from j towards i = -D/d
+            f_vec = -(self.a * w / d)[:, None] * D       # (P, 3)
+            np.add.at(forces, i, f_vec)
+            # pair potential U(r) = (a*rc/2)*(1-r/rc)^2; each pair counted twice
+            energy = np.sum(0.5 * self.a * self.rc * w ** 2) / 2
+
+        self.results = {'energy': energy, 'forces': forces}
+
+
+@pytest.mark.parametrize("seed", [0, 1])
+def test_repulsive_gas(seed):
+    """
+
+    Fluid with smooth repulsive forces between the particles
+
+    This is the same system as model B in Peters Europhys. Lett. (2004)
+
+    """
+
+    REP_AMPLITUDE = 25.0  # repulsive force amplitude
+    N_ATOMS = 500
+    BOX = (N_ATOMS / 4) ** (1 / 3)  # keeps density = 4
+
+
+
+    # --- System setup -------------------------------------------------------------
+    def make_atoms(seed=42):
+        """N_ATOMS unit-mass particles in a cubic box at density 4 with Maxwell-Boltzmann momenta."""
+        rng = np.random.default_rng(seed)
+        positions = rng.uniform(0, BOX, size=(N_ATOMS, 3))
+        atoms = Atoms(
+            ['H'] * N_ATOMS,
+            masses=[MASS] * N_ATOMS,
+            positions=positions,
+            cell=[BOX, BOX, BOX],
+            pbc=True,
+        )
+        atoms.calc = DPDRepulsiveCalculator(a=REP_AMPLITUDE, rc=RC)
+        MaxwellBoltzmannDistribution(atoms, temperature_K=kBT / ase.units.kB,
+                                      rng=np.random.default_rng(seed + 1))
+        Stationary(atoms)
+        return atoms
+
+    def run(atoms, dt, n_eq, n_prod, rng_seed):
+        """Standard Peters thermostat: 1 VV step + 1 thermostat per dt."""
+        dyn = DPDThermostat(
+            atoms, dt,
+            gamma=4.5,
+            cutoff=RC,
+            neighbor_list=matscipy_neighbor_list,
+            T=kBT / ase.units.kB,
+            rng=np.random.default_rng(rng_seed),
+        )
+        for _ in range(n_eq):
+            dyn.step()
+        T_acc = 0.0
+        for _ in range(n_prod):
+            dyn.step()
+            T_acc += kinetic_temperature(atoms)
+        return T_acc / n_prod
+
+    # equally well equilibrated and sampled.
+    T_EQ = 5.0  # DPD time units of equilibration
+    T_PROD = 20.0  # DPD time units of production
+
+    dt = 0.05
+
+    n_eq = max(1, round(T_EQ / dt))
+    n_prod = max(1, round(T_PROD / dt))
+
+    atoms = make_atoms(seed=seed)
+    kT_meas = run(atoms, dt, n_eq, n_prod, rng_seed=seed)
+    print(f"  measured:    kBT = {kT_meas:.4f}", flush=True)
+
+
+    assert abs(kT_meas - kBT) / kBT < 0.05, (
+        f"Temperature kBT = {kT_meas:.1f} K deviates more than 5% from "
+        f"target 1.0 ")

--- a/tests/test_dpd.py
+++ b/tests/test_dpd.py
@@ -4,9 +4,13 @@ import numpy as np
 import pytest
 from ase import Atoms
 from ase.units import kB, fs
+import ase.units
 from ase.calculators.calculator import Calculator, all_changes
+from ase.md.velocitydistribution import MaxwellBoltzmannDistribution, Stationary
+import os
 
 from matscipy.dpd import DPDThermostat
+from matscipy.neighbours import neighbour_list as matscipy_neighbor_list
 
 
 class ZeroForceCalculator(Calculator):
@@ -21,83 +25,150 @@ class ZeroForceCalculator(Calculator):
         }
 
 
-def _make_gas(n=200, density=0.07, symbols='Ar', seed=42):
+def kinetic_temperature(atoms):
+    """Return kBT_kin in DPD units using 3N-3 DOF (momentum conserved)."""
+    p = atoms.get_momenta()
+    m = atoms.get_masses()
+    ekin = 0.5 * np.sum(p ** 2 / m[:, None])
+    n = len(atoms)
+    return 2.0 * ekin / (3 * n - 3)
+
+
+
+# Defining unit system
+kBT = 1.
+MASS = 1.
+RC = 1. # length unit
+
+
+def _make_noninteracting_gas(n=200, density=4,  seed=42, initialize_velocities=True, masses=None):
     """Random positions in a cubic PBC box at given number density (1/Ang^3)."""
     rng = np.random.default_rng(seed)
     L = (n / density) ** (1 / 3)
     positions = rng.uniform(0, L, size=(n, 3))
-    if isinstance(symbols, str):
-        symbols = [symbols] * n
-    atoms = Atoms(symbols, positions=positions, cell=[L, L, L], pbc=True)
-    atoms.set_momenta(np.zeros((n, 3)))
+    atoms = Atoms(['X'] * n, positions=positions, cell=[L, L, L],
+                  masses = masses if masses is not None else [MASS] * n ,  pbc=True)
     atoms.calc = ZeroForceCalculator()
+
+    if initialize_velocities:
+        MaxwellBoltzmannDistribution(atoms, temperature_K=kBT / ase.units.kB,
+                                     rng=np.random.default_rng(seed))
+        Stationary(atoms)
+    else:
+        atoms.set_momenta(np.zeros((n, 3)))
+
+
     return atoms
 
 
-def _kinetic_temperature(atoms):
+
+def _kinetic_kBT(atoms):
     p = atoms.get_momenta()
     m = atoms.get_masses()
     ekin = 0.5 * np.sum(p ** 2 / m[:, None])
-    return 2 * ekin / (3 * len(atoms) * kB)
-
-
-# density=0.07 atoms/Ang^3 gives ~13 neighbors per atom (enough to span
-# all velocity directions efficiently) and gamma=200 gives W~0.1 per pair.
-_COMMON = dict(T=300.0, gamma=200.0, cutoff=3.5, timestep=1 * fs)
+    return 2 * ekin / (3 * len(atoms))
 
 
 class TestDPDThermostat:
+    THERMOSTAT_PARAMETERS = dict(
+        gamma=4.5,
+        cutoff=RC,
+        neighbor_list=matscipy_neighbor_list,
+        T = kBT / ase.units.kB,
+    )
 
-    def test_temperature_convergence(self):
+    @pytest.mark.parametrize("seed", [0,1])
+    def test_temperature_convergence(self, seed, verbose=True):
         """Kinetic temperature must converge to T_target within 5%."""
-        atoms = _make_gas(n=200)
-        dyn = DPDThermostat(atoms, **_COMMON, rng=np.random.default_rng(0))
 
-        for _ in range(200):   # equilibration
+        dt = 0.05
+        t_equil = 3.
+        t_sample = 7.
+
+        n_equil = max(1, round(t_equil / dt))
+        n_sample = max(1, round(t_sample / dt))
+
+        atoms = _make_noninteracting_gas(n=200, density=4, initialize_velocities=False)
+        dyn = DPDThermostat(atoms, dt,
+                            rng = np.random.default_rng(seed),
+                            **self.THERMOSTAT_PARAMETERS
+                            )
+        for _ in range(n_equil):   # equilibration
             dyn.step()
 
-        T_samples = []
-        for _ in range(500):   # production
+        kbT_samples = []
+        for _ in range(n_sample):   # production
             dyn.step()
-            T_samples.append(_kinetic_temperature(atoms))
+            kbT_samples.append(_kinetic_kBT(atoms))
+        kBT_mean = np.mean(kbT_samples)
 
-        T_mean = np.mean(T_samples)
-        assert abs(T_mean - _COMMON['T']) / _COMMON['T'] < 0.05, (
-            f"Temperature {T_mean:.1f} K deviates more than 5% from "
-            f"target {_COMMON['T']} K"
-        )
+        if verbose:
+            import matplotlib.pyplot as plt
+            fig, ax = plt.subplots(figsize=(5, 4))
+            ax.plot(np.arange(n_sample) * dt, kbT_samples, 's-', label='model B')
+            ax.axhline(kBT, ls='--', color='gray', lw=0.8, label='target $k_BT=1$')
+            ax.set_xlabel(r'time')
+            # ax.set_xscale('log')
+            ax.set_ylabel(r'$k_B T$')
+            ax.axhline(kBT_mean)
+            ax.legend()
+            fig.tight_layout()
+            out_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'noninteracting_gas.png')
+            fig.savefig(out_path, dpi=300)
 
-    def test_momentum_conservation(self):
+        print(f'seed {seed}, dt = {dt:.3f}  , kBT {kBT_mean:.5f}')
+        assert abs(kBT_mean - kBT) / kBT < 0.05, (
+            f"Temperature kBT = {kBT_mean:.1f} K deviates more than 5% from "
+            f"target 1.0 ")
+
+
+    @pytest.mark.parametrize("seed", [0, 1])
+    def test_momentum_conservation(self, seed):
         """Total momentum must be conserved exactly (Newton's third law)."""
-        atoms = _make_gas(n=50, seed=1)
-        rng = np.random.default_rng(99)
-        atoms.set_momenta(rng.normal(size=(50, 3)))
+        atoms = _make_noninteracting_gas(n=50, seed=1, density = 4, initialize_velocities=True)
         p0 = atoms.get_momenta().sum(axis=0).copy()
 
-        dyn = DPDThermostat(atoms, **_COMMON, rng=np.random.default_rng(1))
+        dyn = DPDThermostat(atoms, 0.1,
+                            **self.THERMOSTAT_PARAMETERS,
+                            rng=np.random.default_rng(seed))
         for _ in range(100):
             dyn.step()
             p = atoms.get_momenta().sum(axis=0)
             np.testing.assert_allclose(p, p0, atol=1e-10,
                                        err_msg="Total momentum not conserved")
 
-    def test_temperature_convergence_unequal_masses(self):
+    @pytest.mark.parametrize("seed", [0, 1,])
+    def test_temperature_convergence_unequal_masses(self, seed):
         """Temperature must converge with a mixture of two species."""
         n = 200
         symbols = ['Ar'] * (n // 2) + ['Ne'] * (n // 2)
-        atoms = _make_gas(n=n, symbols=symbols, seed=7)
+        atoms = _make_noninteracting_gas(n=n, density=4,
+                                         masses =[1.] * (n // 2) + [4.] * (n // 2),
+                                         seed=seed)
 
-        dyn = DPDThermostat(atoms, **_COMMON, rng=np.random.default_rng(3))
-        for _ in range(500):   # longer equilibration: unequal masses need more steps
+
+        dt = 0.05
+
+        t_equil = 3.
+        n_sample = 500
+
+        n_equil = max(1, round(t_equil / dt))
+
+        dyn = DPDThermostat(atoms, dt,
+                            **self.THERMOSTAT_PARAMETERS,
+                            rng=np.random.default_rng(seed))
+        for _ in range(n_equil):   # longer equilibration: unequal masses need more steps
             dyn.step()
 
-        T_samples = []
-        for _ in range(1000):
+        kBT_samples = []
+        for _ in range(n_sample):
             dyn.step()
-            T_samples.append(_kinetic_temperature(atoms))
+            kBT_samples.append(_kinetic_kBT(atoms))
 
-        T_mean = np.mean(T_samples)
-        assert abs(T_mean - _COMMON['T']) / _COMMON['T'] < 0.05, (
-            f"Temperature {T_mean:.1f} K deviates more than 5% from "
-            f"target {_COMMON['T']} K (unequal masses)"
+        kBT_mean = np.mean(kBT_samples)
+        print(f'seed {seed}, dt = {dt:.3f}  , kBT {kBT_mean:.5f}')
+
+        assert abs(kBT_mean - kBT) / kBT < 0.05, (
+            f"Temperature {kBT_mean:.4f} 1 deviates more than 5% from "
+            f"target 1 "
         )

--- a/tests/test_dpd.py
+++ b/tests/test_dpd.py
@@ -1,0 +1,103 @@
+"""Tests for the Peters DPD thermostat (matscipy.dpd.DPDThermostat)."""
+
+import numpy as np
+import pytest
+from ase import Atoms
+from ase.units import kB, fs
+from ase.calculators.calculator import Calculator, all_changes
+
+from matscipy.dpd import DPDThermostat
+
+
+class ZeroForceCalculator(Calculator):
+    """Returns zero forces, isolating the thermostat from conservative dynamics."""
+    implemented_properties = ['energy', 'forces']
+
+    def calculate(self, atoms=None, properties=None, system_changes=all_changes):
+        Calculator.calculate(self, atoms, properties, system_changes)
+        self.results = {
+            'energy': 0.0,
+            'forces': np.zeros((len(atoms), 3)),
+        }
+
+
+def _make_gas(n=200, density=0.07, symbols='Ar', seed=42):
+    """Random positions in a cubic PBC box at given number density (1/Ang^3)."""
+    rng = np.random.default_rng(seed)
+    L = (n / density) ** (1 / 3)
+    positions = rng.uniform(0, L, size=(n, 3))
+    if isinstance(symbols, str):
+        symbols = [symbols] * n
+    atoms = Atoms(symbols, positions=positions, cell=[L, L, L], pbc=True)
+    atoms.set_momenta(np.zeros((n, 3)))
+    atoms.calc = ZeroForceCalculator()
+    return atoms
+
+
+def _kinetic_temperature(atoms):
+    p = atoms.get_momenta()
+    m = atoms.get_masses()
+    ekin = 0.5 * np.sum(p ** 2 / m[:, None])
+    return 2 * ekin / (3 * len(atoms) * kB)
+
+
+# density=0.07 atoms/Ang^3 gives ~13 neighbors per atom (enough to span
+# all velocity directions efficiently) and gamma=200 gives W~0.1 per pair.
+_COMMON = dict(T=300.0, gamma=200.0, cutoff=3.5, timestep=1 * fs)
+
+
+class TestDPDThermostat:
+
+    def test_temperature_convergence(self):
+        """Kinetic temperature must converge to T_target within 5%."""
+        atoms = _make_gas(n=200)
+        dyn = DPDThermostat(atoms, **_COMMON)
+
+        for _ in range(200):   # equilibration
+            dyn.step()
+
+        T_samples = []
+        for _ in range(500):   # production
+            dyn.step()
+            T_samples.append(_kinetic_temperature(atoms))
+
+        T_mean = np.mean(T_samples)
+        assert abs(T_mean - _COMMON['T']) / _COMMON['T'] < 0.05, (
+            f"Temperature {T_mean:.1f} K deviates more than 5% from "
+            f"target {_COMMON['T']} K"
+        )
+
+    def test_momentum_conservation(self):
+        """Total momentum must be conserved exactly (Newton's third law)."""
+        atoms = _make_gas(n=50, seed=1)
+        rng = np.random.default_rng(99)
+        atoms.set_momenta(rng.normal(size=(50, 3)))
+        p0 = atoms.get_momenta().sum(axis=0).copy()
+
+        dyn = DPDThermostat(atoms, **_COMMON)
+        for _ in range(100):
+            dyn.step()
+            p = atoms.get_momenta().sum(axis=0)
+            np.testing.assert_allclose(p, p0, atol=1e-10,
+                                       err_msg="Total momentum not conserved")
+
+    def test_temperature_convergence_unequal_masses(self):
+        """Temperature must converge with a mixture of two species."""
+        n = 200
+        symbols = ['Ar'] * (n // 2) + ['Ne'] * (n // 2)
+        atoms = _make_gas(n=n, symbols=symbols, seed=7)
+
+        dyn = DPDThermostat(atoms, **_COMMON)
+        for _ in range(500):   # longer equilibration: unequal masses need more steps
+            dyn.step()
+
+        T_samples = []
+        for _ in range(1000):
+            dyn.step()
+            T_samples.append(_kinetic_temperature(atoms))
+
+        T_mean = np.mean(T_samples)
+        assert abs(T_mean - _COMMON['T']) / _COMMON['T'] < 0.05, (
+            f"Temperature {T_mean:.1f} K deviates more than 5% from "
+            f"target {_COMMON['T']} K (unequal masses)"
+        )


### PR DESCRIPTION
Implements the dpd thermostat as described in E. A. J. F. Peters, Europhys. Lett. 66, 311 (2004).

The implementation is based on an implementation in atomistica: https://github.com/Atomistica/atomistica/blob/master/src%2Fstandalone%2Fpeters_t.f90

As in the atomistica implementation, the algorithm deviates a bit from Peters in that after each Verlet step, the velocity updates are all done dimultaneaously based one the relative velocity just after the Verlet step. In Peters each pair is updated sequentially in a randomized manner. 

The approach by Peters has the advantage that they can proove that the maxwell Boltzmann distribution is conserved for any timestep. 

This is probably not anymore exactly the case for the simultaneous update, but the simultaneous update is more efficient. 

As a validation, I reproduced a figure in the paper

Original:
<img width="353" height="284" alt="image" src="https://github.com/user-attachments/assets/ceecb78d-9163-4d07-b10e-b7f41e4ff37f" />

With our code: 
<img width="750" height="600" alt="peters_fig2a_calculated" src="https://github.com/user-attachments/assets/df45c17b-b5e9-4339-bbf3-6b434972eb71" />


The "standard" curve is the normal algorithm with a velocity requilibration after each verlet step and look identical. The subdivided Verlet results suppress the deterministic Verlet discretisation errors by doing 10 smaller Verlet steps before reequilibrating velocities and hence isolates errors associated with the thermostat. The original thermostat is nearly perfect while ours not, probably because of the simultaneous update of the velocities. However, since in practice we would not do Verlet substeps,  the good agreement for the standard algorithm shows that these artefacts do not matter. 


<details>

```python3 
"""Reproduce Peters (2004) Fig. 2a: kinetic temperature vs time step for model B.

Model B (Nikunen et al. 2003): ideal DPD fluid + pairwise repulsive conservative
force F_ij = a*(1-r/rc)*r_hat_ij with a=25, density rho=4, box 10^3.

Two curves compared:
  - Standard: 1 Velocity Verlet step + 1 Peters thermostat step per big dt
  - Subdivided Verlet: 10 VV sub-steps at dt/10 + 1 thermostat step at full dt

All parameters are in DPD reduced units (m=1, rc=1, kBT=1).
The only ASE convention that surfaces is that temperature must be passed as
T = 1/kB so that the thermostat internally computes kB*T = 1.
"""

import os

import numpy as np
import matplotlib.pyplot as plt
from ase import Atoms
from ase.units import kB
from ase.calculators.calculator import Calculator, all_changes
from ase.md.verlet import VelocityVerlet
from ase.md.velocitydistribution import MaxwellBoltzmannDistribution, Stationary

from matscipy.dpd import DPDThermostat
from matscipy.neighbours import neighbour_list as matscipy_nl


# --- DPD reduced-unit parameters ---------------------------------------------

RC = 1.0           # DPD length unit
T_DPD = 1.0 / kB  # kB*T_DPD = 1 (DPD energy unit); kB factor required by ASE convention
GAMMA = 4.5        # DPD friction coefficient
A_CONS = 25.0      # conservative force amplitude
N_ATOMS = 500
BOX = (N_ATOMS / 4) ** (1 / 3)  # keeps density = 4

MASS = 1.0         # DPD mass unit



# --- Conservative force calculator -------------------------------------------

class DPDConservativeCalculator(Calculator):
    """Pairwise repulsive force F_ij = a*(1-r/rc)*r_hat_ij.

    matscipy.neighbour_list returns both (i,j) and (j,i), so forces are
    accumulated only on i.
    """
    implemented_properties = ['energy', 'forces']

    def __init__(self, a=A_CONS, rc=RC):
        super().__init__()
        self.a = a
        self.rc = rc

    def calculate(self, atoms=None, properties=None, system_changes=all_changes):
        Calculator.calculate(self, atoms, properties, system_changes)
        n = len(atoms)
        forces = np.zeros((n, 3))
        energy = 0.0

        i, j, D, d = matscipy_nl('ijDd', atoms, cutoff=self.rc)

        if len(i) > 0:
            w = 1.0 - d / self.rc                        # (1-r/rc), shape (P,)
            # D = r_j - r_i; repulsive force on i points from j towards i = -D/d
            f_vec = -(self.a * w / d)[:, None] * D       # (P, 3)
            np.add.at(forces, i, f_vec)
            # pair potential U(r) = (a*rc/2)*(1-r/rc)^2; each pair counted twice
            energy = np.sum(0.5 * self.a * self.rc * w ** 2) / 2

        self.results = {'energy': energy, 'forces': forces}


# --- System setup -------------------------------------------------------------

def make_model_b(seed=42):
    """N_ATOMS unit-mass particles in a cubic box at density 4 with Maxwell-Boltzmann momenta."""
    rng = np.random.default_rng(seed)
    positions = rng.uniform(0, BOX, size=(N_ATOMS, 3))
    atoms = Atoms(
        ['H'] * N_ATOMS,
        masses=[MASS] * N_ATOMS,
        positions=positions,
        cell=[BOX, BOX, BOX],
        pbc=True,
    )
    atoms.calc = DPDConservativeCalculator()
    MaxwellBoltzmannDistribution(atoms, temperature_K=T_DPD,
                                  rng=np.random.default_rng(seed + 1))
    Stationary(atoms)
    return atoms


def kinetic_temperature(atoms):
    """Return kBT_kin in DPD units using 3N-3 DOF (momentum conserved)."""
    p = atoms.get_momenta()
    m = atoms.get_masses()
    ekin = 0.5 * np.sum(p ** 2 / m[:, None])
    n = len(atoms)
    return 2.0 * ekin / (3 * n - 3)


# --- Simulation runners -------------------------------------------------------

def run_standard(atoms, dt, n_eq, n_prod, rng_seed):
    """Standard Peters thermostat: 1 VV step + 1 thermostat per dt."""
    dyn = DPDThermostat(
        atoms, dt, T_DPD, gamma=GAMMA, cutoff=RC,
        rng=np.random.default_rng(rng_seed),
        logfile=None,
    )
    for _ in range(n_eq):
        dyn.step()
    T_acc = 0.0
    for _ in range(n_prod):
        dyn.step()
        T_acc += kinetic_temperature(atoms)
    return T_acc / n_prod


def run_subdivided(atoms, big_dt, n_sub, n_eq, n_prod, rng_seed):
    """Subdivided Verlet: n_sub VV steps at big_dt/n_sub + 1 thermostat at big_dt."""
    sub_dt = big_dt / n_sub
    # sub_verlet integrates the conservative forces in sub-steps
    sub_verlet = VelocityVerlet(atoms, sub_dt, logfile=None)
    # dpd provides _apply_thermostat() which uses self.dt = big_dt for W
    dpd = DPDThermostat(
        atoms, big_dt, T_DPD, gamma=GAMMA, cutoff=RC,
        rng=np.random.default_rng(rng_seed),
        logfile=None,
    )

    def big_step():
        for _ in range(n_sub):
            sub_verlet.step()
        dpd._apply_thermostat()

    for _ in range(n_eq):
        big_step()
    T_acc = 0.0
    for _ in range(n_prod):
        big_step()
        T_acc += kinetic_temperature(atoms)
    return T_acc / n_prod


# --- Parameter scan -----------------------------------------------------------

# Time steps in DPD units (= ASE time units with our mapping)
DT_VALUES = np.array([0.01, 0.02, 0.04, 0.06, 0.08, 0.10])
# Fix total simulated time rather than step count so all dt values are
# equally well equilibrated and sampled.
T_EQ = 5.0    # DPD time units of equilibration
T_PROD = 40.0  # DPD time units of production
N_SUB = 10

kT_standard = []
kT_subdivided = []

for k, dt in enumerate(DT_VALUES):
    n_eq = max(1, round(T_EQ / dt))
    n_prod = max(1, round(T_PROD / dt))
    print(f"dt = {dt:.3f}  ({k + 1}/{len(DT_VALUES)})  "
          f"n_eq={n_eq} n_prod={n_prod}", flush=True)

    atoms = make_model_b(seed=k)
    kT_std = run_standard(atoms, dt, n_eq, n_prod, rng_seed=100 + k)
    kT_standard.append(kT_std)
    print(f"  standard:    kBT = {kT_std:.4f}", flush=True)

    atoms = make_model_b(seed=k)
    kT_sub = run_subdivided(atoms, dt, N_SUB, n_eq, n_prod, rng_seed=200 + k)
    kT_subdivided.append(kT_sub)
    print(f"  subdivided:  kBT = {kT_sub:.4f}", flush=True)

kT_standard = np.array(kT_standard)
kT_subdivided = np.array(kT_subdivided)

# --- Plot -------------------------------------------------------------------

fig, ax = plt.subplots(figsize=(5, 4))
ax.plot(DT_VALUES, kT_standard, 's-', label='model B')
ax.plot(DT_VALUES, kT_subdivided, 'o-', label='model B, subdivided Verlet')
ax.axhline(1.0, ls='--', color='gray', lw=0.8, label='target $k_BT=1$')
ax.set_xlabel(r'$\Delta t$')
ax.set_xscale('log')
ax.set_ylabel(r'$k_B T$')
ax.set_title("Peters (2004) Fig. 2a – model B")
ax.legend()
fig.tight_layout()

out_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'peters_fig2a.png')
fig.savefig(out_path, dpi=150)
print(f"\nSaved figure to {out_path}")
plt.show()

```
</details>

Remaining TODO items: 

- [ ] Cleanup the tests
- [ ] ? Example notebook with this figure reproduction ? 
- [ ] should we use the matscipy neighborlist  instead of ASE ? 
