### PR TITLE
BUG: Fix doc build — Fraction() failure on float32 Burgers vectors in view_cyl

### DIFF
--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -3621,7 +3621,7 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
 
             # Use burgers vector to get a key for the dislocation line colour
             # Sorting and abs remove the rotational dependance, reducing the number of possible keys
-            colour_key = " ".join([str(Fraction(elem).limit_denominator(10)) for elem in b_sorted])
+            colour_key = " ".join([str(Fraction(float(elem)).limit_denominator(10)) for elem in b_sorted])
 
             if color is None:
                 if colour_key in disloc_colours[self.crystalstructure.lower()]:
@@ -3633,7 +3633,7 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
                 colour = color[idx]
 
             if disloc_names is None:
-                seg_name = f"b=[" + " ".join([str(Fraction(elem).limit_denominator(10)) for elem in b]) + "]"
+                seg_name = f"b=[" + " ".join([str(Fraction(float(elem)).limit_denominator(10)) for elem in b]) + "]"
             else:
                 seg_name = disloc_names[idx]
 


### PR DESCRIPTION
## Summary

Fixes the failing **Documentation** CI job (`docs/applications/cylinder_configurations.ipynb`).

The failure is **not** a dependency/pin issue (the `ipykernel`/`pyzmq` `ZMQError: Socket operation on non-socket` seen in the log is harmless teardown noise). The real error is a `CellExecutionError` from matscipy's own code:

```
TypeError: argument should be a string or a Rational instance
  matscipy/dislocation.py:3624 in _plot_DXA_disloc_line
    colour_key = " ".join([str(Fraction(elem).limit_denominator(10)) for elem in b_sorted])
```

## Root cause

`CubicCrystalDislocation.view_cyl` → `_plot_DXA_disloc_line` builds a colour key and segment label by passing each Burgers-vector component to `fractions.Fraction`. The components come from `segment.true_burgers_vector`, which newer OVITO returns as **`numpy.float32`**. `Fraction()` accepts `int`, `float`, `Decimal`, `str` or `numbers.Rational` — and `numpy.float32` is **not** a subclass of Python `float` (only `numpy.float64` is), so it raises `TypeError`.

Reproduced in isolation:
```python
from fractions import Fraction
import numpy as np
Fraction(np.float64(0.5))   # OK
Fraction(np.float32(0.5))   # TypeError: argument should be a string or a Rational instance
Fraction(float(np.float32(0.5)))  # OK  <- the fix
```

## Fix

Convert each component to a native Python `float` before constructing the `Fraction`, at both call sites in `_plot_DXA_disloc_line`.

## Testing

OVITO is an optional heavyweight dependency not installed in the dev env and there is no unit test covering `view_cyl`, so verification is by isolated reproduction of the exact failing expression (above): `Fraction(float(np.float32(...)))` succeeds where `Fraction(np.float32(...))` raised. This is the precise expression and value type from the failing notebook cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)