### PR TITLE
Add matscipy as an ASE v4 neighbour-list plugin

### DIFF
--- a/matscipy/_ase_plugin.py
+++ b/matscipy/_ase_plugin.py
@@ -1,0 +1,51 @@
+"""ASE v4 neighbour-list plugin for matscipy.
+
+Registers matscipy's compiled neighbour list as an ``ase.plugins`` backend, so
+it can be selected *explicitly* via :func:`ase.neighborlist.get_neighbor_list`
+(or, in due course, a calculator's ``neighbor_list=`` option).  Selection is
+never automatic -- this only makes the backend *available* under the name
+``"matscipy"``.
+
+This module is the ``ase.plugins`` entry point (it exposes ``__ase_plugins__``).
+The plugin registration is guarded so that installing matscipy alongside an ASE
+that predates the v4 plugin API registers nothing rather than breaking plugin
+discovery.  The heavy import of :mod:`matscipy.neighbours` happens lazily,
+inside the adapter, so merely building the plugin collection does not import the
+compiled extension.
+"""
+from __future__ import annotations
+
+
+def neighbor_list(quantities, atoms, cutoff, *, self_interaction=False):
+    """matscipy neighbour list adapted to ASE's ``NeighborListFunction``.
+
+    matscipy's ``neighbour_list`` returns the same ``(i, j, d, D, S)`` flat
+    arrays and quantity letters as ``ase.neighborlist.neighbor_list``, but has
+    no ``self_interaction`` option (it never returns pure self-pairs).  Per the
+    plugin contract, a request it cannot honour is rejected rather than
+    silently differing, so ``self_interaction=True`` raises.
+    """
+    if self_interaction:
+        raise NotImplementedError(
+            'the matscipy neighbour-list backend does not support '
+            'self_interaction=True')
+    from matscipy.neighbours import neighbour_list as _matscipy_neighbour_list
+
+    return _matscipy_neighbour_list(quantities, atoms, cutoff)
+
+
+try:
+    from ase._4.plugins.neighborlist import NeighborListPlugin
+except ImportError:
+    # ASE without the v4 plugin API: register nothing, but do not break the
+    # discovery of other plugins.
+    __ase_plugins__: set = set()
+else:
+    __ase_plugins__ = {
+        NeighborListPlugin(
+            'matscipy',
+            long_name='matscipy compiled neighbour list',
+            citation='https://github.com/libAtoms/matscipy',
+            implementation='matscipy._ase_plugin.neighbor_list',
+        ),
+    }

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -3621,7 +3621,7 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
 
             # Use burgers vector to get a key for the dislocation line colour
             # Sorting and abs remove the rotational dependance, reducing the number of possible keys
-            colour_key = " ".join([str(Fraction(elem).limit_denominator(10)) for elem in b_sorted])
+            colour_key = " ".join([str(Fraction(float(elem)).limit_denominator(10)) for elem in b_sorted])
 
             if color is None:
                 if colour_key in disloc_colours[self.crystalstructure.lower()]:
@@ -3633,7 +3633,7 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
                 colour = color[idx]
 
             if disloc_names is None:
-                seg_name = f"b=[" + " ".join([str(Fraction(elem).limit_denominator(10)) for elem in b]) + "]"
+                seg_name = f"b=[" + " ".join([str(Fraction(float(elem)).limit_denominator(10)) for elem in b]) + "]"
             else:
                 seg_name = disloc_names[idx]
 

--- a/matscipy/meson.build
+++ b/matscipy/meson.build
@@ -12,6 +12,7 @@ version_file = configure_file(
 python_sources = [
     '__init__.py',
     version_file,
+    '_ase_plugin.py',
     'angle_distribution.py',
     'atomic_strain.py',
     'compat.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ matscipy-sinclair-crack = "matscipy.cli.fracture_mechanics.sinclair_crack:main"
 # Interatomic potentials
 matscipy-average-eam-potential = "matscipy.cli.calculators.average_eam_potential:main"
 
+# Expose matscipy's compiled neighbour list as an ASE v4 neighbour-list backend
+[project.entry-points."ase.plugins"]
+matscipy_neighbours = "matscipy._ase_plugin"
+
 [project.urls]
 documentation = "http://libatoms.github.io/matscipy/"
 repository = "https://github.com/libAtoms/matscipy"


### PR DESCRIPTION
## Summary

Exposes matscipy's compiled neighbour list as a **user-selectable** neighbour-list backend for ASE 4 (`ase._4`), via the single `ase.plugins` entry-point group. When matscipy is installed, ASE callers can opt in explicitly:

```python
from ase.neighborlist import get_neighbor_list, available_neighbor_list_backends
available_neighbor_list_backends()      # {'ase': True, 'matscipy': True, ...}
nl = get_neighbor_list("matscipy")      # the compiled backend
i, j, d, D, S = nl("ijdDS", atoms, 5.0)
```

Selection is **explicit and never automatic** — this only makes the backend *available* under the name `"matscipy"`; ASE still defaults to its built-in `"ase"` backend.

## What's here

- **`matscipy/_ase_plugin.py`** — a thin adapter matching ASE's `NeighborListFunction` contract (`fn(quantities, atoms, cutoff, *, self_interaction=False)`). matscipy's `neighbour_list` already returns the same `(i, j, d, D, S)` flat arrays and quantity letters; the adapter only adds the `self_interaction` keyword, rejecting `self_interaction=True` (which matscipy does not support) rather than silently differing. The heavy `matscipy.neighbours` import is lazy (only on call), and the `__ase_plugins__` registration is **guarded** so installing matscipy alongside an ASE that predates the v4 plugin API registers nothing instead of breaking plugin discovery.
- **`pyproject.toml`** — declares the `ase.plugins` entry point (`matscipy_neighbours = "matscipy._ase_plugin"`).
- **`matscipy/meson.build`** — installs the new module.

## Notes / dependencies

- Targets ASE's in-flight v4 plugin system (the `ase.plugins` entry-point group + `NeighborListPlugin` type). On current released ASE the guard makes this a no-op, so it is safe to merge ahead of that landing.
- Validated against an ASE branch carrying the v4 `NeighborListPlugin`: matscipy's edge sets are byte-identical to ASE's reference backend across fcc, hcp, and mixed-pbc slab systems (cutoffs 3 and 5 Å), the `D = pos[j] - pos[i] + S @ cell` identity holds, and matscipy works through ASE's backend-agnostic Verlet skin-reuse wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)