### PR TITLE
ENH: per-atom site energies and virials in the Manybody calculator

### DIFF
--- a/matscipy/calculators/manybody/calculator.py
+++ b/matscipy/calculators/manybody/calculator.py
@@ -75,7 +75,9 @@ class Manybody(MatscipyCalculator):
     implemented_properties = [
         'free_energy',
         'energy',
+        'energies',
         'stress',
+        'stresses',
         'forces',
         'hessian',
         'born_constants',
@@ -197,9 +199,28 @@ class Manybody(MatscipyCalculator):
 
         virial_v *= 0.5
 
+        # Per-atom decomposition (additive; needed for e.g. the J-integral,
+        # per-site energy checks and atomic-strain work). The pair energy F_p
+        # is split equally between its two atoms -> site energy
+        # e_n = 0.5 * sum_{p: i_p=n} F_p; likewise the per-pair virial r (x) f is
+        # accumulated on the home atom with the same 0.5 factor. By construction
+        # sum_n e_n = epot and sum_n W_n = global virial.
+        energies_n = 0.5 * np.bincount(i_p, weights=F_p, minlength=nb_atoms)
+        w_pab = np.einsum('pa,pb->pab', r_pc, f_pc)
+        virial_nab = np.zeros((nb_atoms, 3, 3))
+        np.add.at(virial_nab, i_p, w_pab)
+        virial_nab *= 0.5
+        # ASE per-atom stresses (Voigt, n x 6): xx, yy, zz, yz, xz, xy
+        stresses_nv = np.stack([
+            virial_nab[:, 0, 0], virial_nab[:, 1, 1], virial_nab[:, 2, 2],
+            virial_nab[:, 1, 2], virial_nab[:, 0, 2], virial_nab[:, 0, 1],
+        ], axis=1) / atoms.get_volume()
+
         self.results.update({'free_energy': epot,
                              'energy': epot,
+                             'energies': energies_n,
                              'stress': virial_v / atoms.get_volume(),
+                             'stresses': stresses_nv,
                              'forces': f_nc})
 
     def get_hessian(self, atoms, format='sparse', divide_by_masses=False):

--- a/tests/manybody/test_per_atom_decomposition.py
+++ b/tests/manybody/test_per_atom_decomposition.py
@@ -1,0 +1,72 @@
+#
+# Copyright 2026 James Kermode (U. Warwick)
+#
+# matscipy - Materials science with Python at the atomic-scale
+# https://github.com/libAtoms/matscipy
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Per-atom decomposition of the (public) Manybody calculator.
+
+The calculator now exposes per-atom site energies (``energies``) and per-atom
+stresses (``stresses``). They are defined so that they sum exactly to the
+global energy and global virial respectively; this test verifies that
+consistency for the Stillinger-Weber form on bulk Si, including a sheared cell
+that breaks the cubic symmetry (so the off-diagonal virial components are
+exercised).
+"""
+
+import numpy as np
+import numpy.testing as nt
+
+from ase.lattice.cubic import Diamond
+
+from matscipy.calculators.manybody import Manybody
+from matscipy.calculators.manybody.explicit_forms import StillingerWeber
+from matscipy.calculators.manybody.explicit_forms.stillinger_weber import (
+    Stillinger_Weber_PRB_31_5262_Si,
+)
+
+
+def _si(cell_transform=None):
+    atoms = Diamond("Si", latticeconstant=5.43, size=(2, 2, 2))
+    if cell_transform is not None:
+        atoms.set_cell(atoms.cell @ cell_transform, scale_atoms=True)
+    atoms.calc = Manybody(**StillingerWeber(Stillinger_Weber_PRB_31_5262_Si))
+    return atoms
+
+
+def test_site_energies_sum_to_total():
+    for T in (None, np.array([[1.0, 0.02, 0.0],
+                              [0.0, 0.99, 0.0],
+                              [0.0, 0.0, 1.01]])):
+        atoms = _si(T)
+        E = atoms.get_potential_energy()
+        e_n = atoms.get_potential_energies()
+        assert e_n.shape == (len(atoms),)
+        nt.assert_allclose(e_n.sum(), E, rtol=0, atol=1e-10)
+
+
+def test_per_atom_virial_sums_to_global():
+    # shear so all six virial components are non-trivial
+    T = np.array([[1.0, 0.02, 0.0],
+                  [0.0, 0.99, 0.0],
+                  [0.0, 0.0, 1.01]])
+    atoms = _si(T)
+    atoms.get_potential_energy()
+    W_nv = atoms.calc.results["stresses"]            # (N, 6), per-atom stress
+    assert W_nv.shape == (len(atoms), 6)
+    global_v = atoms.get_stress()                    # (6,) global stress
+    nt.assert_allclose(W_nv.sum(axis=0), global_v, rtol=0, atol=1e-10)


### PR DESCRIPTION
## What

Expose per-atom decompositions from the (public) `Manybody` calculator
(`matscipy/calculators/manybody/calculator.py`) as the standard ASE per-atom
properties:

- **`energies`** — site energies, `e_n = 0.5 * sum_{p: i_p = n} F_p`
- **`stresses`** — per-atom virial `r (x) f` accumulated on the home atom with the
  same `0.5` factor (Voigt `n x 6`)

Both are **purely additive**: `energy`, `stress` and `forces` are untouched, and by
construction `sum(energies) == energy` and `sum(per-atom virial) == global virial`.

## Why

The many-body calculators previously exposed only global energy/stress, so anything
needing a per-atom hook had no access to it — in particular
`matscipy.fracture_mechanics.energy_release.J_integral` (which takes per-atom
energies and per-atom virials), per-site energy checks, and atomic-strain work. This
came up while building a from-scratch Sinclair flexible-BC fracture reference oracle
(same campaign as #320, #321, #322).

## Validation

`sum(energies) == energy` to ~1e-13 and `sum(per-atom stress) == global stress` to
~1e-17 for Stillinger–Weber (SW-Si) and Tersoff/Erhart–Albe (3C-SiC), including
sheared cells (all six virial components exercised). Test added in
`tests/manybody/test_per_atom_decomposition.py`.

## Notes / caveats

- Marked **draft**: developed in an environment without the built extension / pytest,
  so the change was validated by reproducing the decomposition against the installed
  release (sums to machine precision) rather than by running the suite locally —
  please let CI confirm.
- Targets the exported `calculator.py` `Manybody`. The separate `newmb.Manybody`
  could mirror this if desired (left out here to keep the change focused).
- Two further robustness items from the same campaign (opt-in graph-based
  `set_sublattices`; parametrising `eval_shift`'s relaxation `fmax`) are
  behaviour-sensitive (they touch values pinned by existing tests) and are tracked
  separately rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
