### PR TITLE
Fix memory leak in resize_array: free dims after PyArray_Resize

### DIFF
--- a/c/tools.c
+++ b/c/tools.c
@@ -82,6 +82,7 @@ resize_array(PyObject *py_arr, npy_intp newsize)
         
     PyObject *retval;
     retval = PyArray_Resize((PyArrayObject *) py_arr, &newshape, 1, NPY_CORDER);
+    free(dims);
     if (!retval)  return NULL;
     Py_DECREF(retval);
 


### PR DESCRIPTION
I noticed in my wandb graphs that there was a memory leak while training. Fable tracked it down to this bug.

I think this change looks correct since we need to free the malloc array, and after we reshape py_arr to get retval, I don't think we need the newshape object anymore, so we should free the dims array.
